### PR TITLE
retrieve all elements, not just first 50

### DIFF
--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -82,7 +82,7 @@ class SevenBridgesPlatform(Platform):
         else:
             parent = parent[0]
             for folder in folders[1:]:
-                nested = [x for x in parent.list_files() if x.name == folder]
+                nested = [x for x in parent.list_files().all() if x.name == folder]
                 if not nested:
                     parent = self.api.files.create_folder(
                         name=folder,


### PR DESCRIPTION
When traversing the SBG folder tree, we were listing only the first 50 elements (default for the sevenbridges-python list_files method). For folders with more than this number of folder/file objects, this means we may erroneously attempt to create a folder which already exists but which wasn't returned in first 50, resulting in a platform error.

this PR adds the .all() call to get all file elements, not just the first 50.

confirmed on the SBG platform that this resolves the issue.