### PR TITLE
Function for generic export

### DIFF
--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -440,7 +440,13 @@ class ArvadosPlatform(Platform):
         '''
         take list of file paths
         copy to destination
+        if the destination is already the prefix to any filepaths, it will not nest the destination path
+
+        :param project: The project to stage files to
+        :param files: list of filepaths that need to be moved
+        :param destination: destination folder.
         '''
+        
         # set up destination collection name and path
         if destination.startswith('/'):
             dest_name = destination.split('/')[1]

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -436,6 +436,77 @@ class ArvadosPlatform(Platform):
             return search_result['items'][0]
         return None
 
+    def move_files(self, project, files, destination):
+        '''
+        take list of file paths
+        copy to destination
+        '''
+        # set up destination collection name and path
+        if destination.startswith('/'):
+            dest_name = destination.split('/')[1]
+            dest_path = '/'.join(destination.split('/')[2:]) + '/'
+        else:
+            dest_name = destination.split('/')[0]
+            dest_path = '/'.join(destination.split('/')[1:]) + '/'
+            
+        # Get the destination project collection
+        search_result = self.api.collections().list(filters=[
+            ["owner_uuid", "=", project["uuid"]],
+            ["name", "=", dest_name]
+            ]).execute()
+        if len(search_result['items']) > 0:
+            dest_coll = search_result['items'][0]
+            dest_coll_filesgen = arvados.collection.CollectionReader(dest_coll['current_version_uuid']).all_files()
+            dest_coll_files = [j.stream_name()[2:] + '/' + j.name() for j in dest_coll_filesgen]
+        else:
+            dest_coll = self.api.collections().create(body={
+                "owner_uuid": project["uuid"],
+                "name": dest_name,
+                "preserve_version":True}).execute()
+            dest_coll_files = []
+
+        # Get target
+        target = arvados.collection.Collection(dest_coll['uuid'], api_client=self.api, keep_client=self.keep_client)
+
+        # loop through file paths
+        for i in files:
+            if i.startswith('/'):
+                orig_name = i.split('/')[1]
+                orig_path = '/'.join(i.split('/')[2:])
+            else:
+                orig_name = i.split('/')[0]
+                orig_path = '/'.join(i.split('/')[1:])
+            try:
+                # check if file exists and prepend new version number if so
+                count = 0
+                dup = True
+                if dest_path.startswith('/'):
+                    clean_dest = dest_path[1:]
+                else:
+                    clean_dest = dest_path
+                new_path = clean_dest + orig_path
+                
+                while dup:
+                    if new_path in dest_coll_files:
+                        count += 1
+                        new_path = clean_dest[:-1] + '/'.join(orig_path.split('/')[:-1]) + '/v' + str(count) + '_' + orig_path.split('/')[-1]
+                    else:
+                        dup = False
+                    
+                search_result = self.api.collections().list(filters=[
+                    ["owner_uuid", "=", project["uuid"]],
+                    ["name", "=", orig_name]
+                    ]).execute()
+                orig_coll = search_result['items'][0]
+                source = arvados.collection.CollectionReader(orig_coll['uuid']) 
+                target.copy(orig_path,
+                            target_path = new_path,
+                            source_collection = source,
+                            overwrite = False)
+            except IOError:
+                continue
+        target.save()
+    
     def stage_output_files(self, project, output_files):
         '''
         Stage output files to a project

--- a/src/cwl_platform/base_platform.py
+++ b/src/cwl_platform/base_platform.py
@@ -103,6 +103,18 @@ class Platform(ABC):
         self.logger = logger
 
     @abstractmethod
+    def move_files(self, project, files, destination):
+        '''
+        take list of file paths
+        copy to destination
+        if the destination is already the prefix to any filepaths, it will not nest the destination path
+
+        :param project: The project to stage files to
+        :param files: list of filepaths that need to be moved
+        :param destination: destination folder.
+        '''
+        
+    @abstractmethod
     def stage_output_files(self, project, output_files):
         '''
         Stage output files to a project

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -433,6 +433,32 @@ class SevenBridgesPlatform(Platform):
         ''' Get a project by its id '''
         return self.api.projects.get(project_id)
 
+    def move_files(self, project, files, destination):
+        '''
+        take list of file paths
+        copy to destination
+        if the destination is already the prefix to any filepaths, it will not 
+
+        :param project: The project to stage files to
+        :param files: list of filepaths that need to be moved
+        :param destination: destination folder.
+        '''
+        for i in files:
+            logger.info('moving this file ' + i)
+            fileid = self.get_file_id(project, i)
+            f = self.api.files.get(fileid)
+
+            # check if destination already matches
+            if i.startswith(destination):
+                dest = self._find_or_create_path(project, '/' + '/'.join(i.split('/')[0:-1]))
+            else:
+                if len(i.split('/')) > 1:
+                    dest = self._find_or_create_path(project, destination + '/' + '/'.join(i.split('/')[0:-1]))
+                else:
+                    dest = self._find_or_create_path(project, destination)
+            f.move_to_folder(parent = dest, name = i.split('/')[-1])
+        return destination
+    
     def stage_output_files(self, project, output_files):
         '''
         Stage output files to a project

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -437,7 +437,7 @@ class SevenBridgesPlatform(Platform):
         '''
         take list of file paths
         copy to destination
-        if the destination is already the prefix to any filepaths, it will not 
+        if the destination is already the prefix to any filepaths, it will not nest the destination path
 
         :param project: The project to stage files to
         :param files: list of filepaths that need to be moved


### PR DESCRIPTION
This PR adds a `move_files()` function to the SBG and Arvados platform code. This function takes a list of file paths and a destination path, and moves the files in the list such that the new paths have the destination path prepended. In the case that the destination path is already an exact prefix of a filepath, then the file will not be moved. If a file with the same name already exists in the destination folder, the file being moved will be renamed to mark a new version.

I'm told that some folks have found this helpful for moving files to an OUTPUTS folder as required for export by the generic project class in NGS360. 

Example implementation of `move_files()` in the `collect_outputs()` function of the 10X Launcher: https://github.com/bmsgh/10X-Launcher-new/blob/5481bd5a6ff632bc2a6cfb8fcbdcc063bad955dd/launcher/src/launcher.py#L745 

