### PR TITLE
Feature sbg task retries

### DIFF
--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -625,3 +625,17 @@ class ArvadosPlatform(Platform):
                 arv_file.write(local_content) # pylint: disable=no-member
             target_collection.save()
         return f"keep:{destination_collection['uuid']}/{target_filepath}"
+
+    def monitor_task(self, task):
+        '''
+        Takes a task
+        Waits until it is done
+        Placeholder for now, but room to implement automatic retries in the future
+        '''
+        state = self.get_task_state(task, refresh=True)
+        while state not in ('Completed', 'Cancelled', 'Failed', 'NA'):
+            logger.debug(" - Sleeping for 60 seconds")
+            time.sleep(60)
+            state = self.get_task_state(task, refresh=True)
+
+        return(task) 

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -631,6 +631,7 @@ class ArvadosPlatform(Platform):
         Takes a task
         Waits until it is done
         Placeholder for now, but room to implement automatic retries in the future
+        :param task: task to monitor 
         '''
         state = self.get_task_state(task, refresh=True)
         while state not in ('Completed', 'Cancelled', 'Failed', 'NA'):

--- a/src/cwl_platform/base_platform.py
+++ b/src/cwl_platform/base_platform.py
@@ -152,3 +152,11 @@ class Platform(ABC):
         :param overwrite: Overwrite the file if it already exists.
         :return: ID of uploaded file.
         '''
+        
+    @abstractmethod
+    def monitor_task(self, task):
+        '''
+        Monitor a task on the platform, resubmit on a larger instance
+        if failed due to reasons in SevenBridgesInstance.errors
+        :param task: task to monitor
+        '''

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -570,6 +570,7 @@ class SevenBridgesPlatform(Platform):
         '''
         Monitor a task on the platform, resubmit on a larger instance
         if failed due to reasons in SevenBridgesInstance.errors
+        :param task: task to monitor 
         '''
         count = 0
         while task.status not in sevenbridges.TaskStatus.terminal_states:


### PR DESCRIPTION
This PR adds task retry functionality to the SBG platform as the launcher waits for tasks to complete. This is implemented in the `monitor_task()` function which does the following:
- for SBG: the function checks the task status every 60 seconds. If it finds that a task exited with a pre-specified list of error messages (defined in`SevenBridgesInstance` class), it will resubmit the task up to three times on progressively larger instances also defined in the `SevenBridgesInstance` class. It returns either a completed task or a failed task that has been retried. 
- for arvados: the function checks the state of the task every 60 seconds. It exits and returns either a completed or failed task. 