### PR TITLE
Update code to support China instance of the SB platform

### DIFF
--- a/src/cwl_platform/__init__.py
+++ b/src/cwl_platform/__init__.py
@@ -5,15 +5,18 @@ import logging
 import os
 
 from .arvados_platform import ArvadosPlatform
-from .sevenbridges_platform import SevenBridgesPlatform
+from .sevenbridges_platform import SevenBridgesPlatform_US, \
+    SevenBridgesPlatform_CN
 #from .omics_platform import OmicsPlatform
 
 # Move this for a config file
 SUPPORTED_PLATFORMS = {
     'Arvados': ArvadosPlatform,
 #    'Omics': OmicsPlatform,
-    'SevenBridges': SevenBridgesPlatform
+    'SevenBridges_US': SevenBridgesPlatform_US,
+    'SevenBridges_CN': SevenBridgesPlatform_CN
 }
+
 
 class PlatformFactory():
     ''' PlatformFactory '''

--- a/src/cwl_platform/platform_config.py
+++ b/src/cwl_platform/platform_config.py
@@ -1,0 +1,28 @@
+
+sb_credentials = {
+    'US': {
+        'api_endpoint': 'https://bms-api.sbgenomics.com/v2',
+        'token': 'dummy',
+        'profile': 'default'
+    },
+    'CN': {
+        'api_endpoint': 'https://api.sevenbridges.cn/v2',
+        'token': 'dummy',
+        'profile': 'china'
+    }
+}
+
+sb_execution_settings = {
+    'US': {
+        'use_elastic_disk': True,
+        'use_memoization': True,
+        'use_spot_instance': True,
+        "max_parallel_instances": 1
+    },
+    'CN': {
+        'use_elastic_disk': False,
+        'use_memoization': True,
+        'use_spot_instance': True,
+        "max_parallel_instances": 1
+    }
+}


### PR DESCRIPTION
Hi Ryan, we updated the code to support SB China Platform:

- In the sevenbridges_platform.py, we added two child classes (SevenBridgesPlatform_US and SevenBridgesPlatform_CN) that inherit the functionality from SevenBridgesPlatform class, but have unique **_detect_** method and some platform configuration settings. Note: the detect method actually tries to connect to the US or CN platform because there is no other way to detect what platform the launcher is running on.
- In regard to that, we updated SUPPORTED_PLATFORMS dict in __init__.py to include US and CN SB platforms.
- platform_config.py file was added. It contains sb_credentials and sb_execution_settings, so those things are not hardcoded in the sevenbridges_platform.py