### PR TITLE
Add a check to ensure output is present

### DIFF
--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -91,6 +91,9 @@ class ArvadosPlatform(Platform):
         cwl_output_collection = arvados.collection.Collection(task.container_request['output_uuid'],
                                                               api_client=self.api,
                                                               keep_client=self.keep_client)
+        if cwl_output_collection.items() is None:
+            return None
+
         cwl_output = None
         with cwl_output_collection.open('cwl.output.json') as cwl_output_file:
             cwl_output = json.load(cwl_output_file)


### PR DESCRIPTION
Sometimes cwl.output.json is not present in the output collection.  This adds a check to make sure there are contents prior to querying.