### PR TITLE
Fix arvados-cwl-runner to <3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 chardet
-arvados-python-client
+arvados-python-client<=3.0.0
 sevenbridges-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 chardet
-arvados-python-client<=3.0.0
+arvados-python-client<3.0.0
 sevenbridges-python


### PR DESCRIPTION
3.0.0 breaks the all_files() method.