### PR TITLE
Use find for find python files for linting instead of git ls-files

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,4 +34,4 @@ jobs:
 
     - name: Analysing the code with pylint
       run: |
-        pylint --max-line-length=120 --ignore-imports=y $(git ls-files '*.py')
+        make lint

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,5 @@ test:
 	coverage html
 
 lint:
-	pylint --max-line-length=120 --ignore-imports=y --exit-zero $$(git ls-files '*.py')
+	find . -name "*.py" | xargs pylint --max-line-length=120 --ignore-imports=y --exit-zero
+


### PR DESCRIPTION
Linting is slightly broken when run in docker container.  This PR fixes it.