### PR TITLE
Add check for Arvados when an optional output for a step is missing

### DIFF
--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -422,6 +422,9 @@ class ArvadosPlatform(Platform):
 
         output_field = cwl_output[output_name]
 
+        if output_field is None:
+            return None
+
         if isinstance(output_field, list):
             # If the output is a list, return a list of file locations
             output_files = []

--- a/tests/test_arvados_platform.py
+++ b/tests/test_arvados_platform.py
@@ -56,6 +56,18 @@ class TestArvadosPlaform(unittest.TestCase):
         actual_value = self.platform.get_task_output(task, 'some_output_field')
         # Check results
         self.assertIsNone(actual_value)
+        
+    @mock.patch('cwl_platform.arvados_platform.ArvadosPlatform._load_cwl_output')
+    def test_get_task_output_nonexistent_output(self, mock__load_cwl_output):
+        ''' Test that get_task_output can handle cases when the output is non-existent in cwl_output '''
+        # Set up test parameters
+        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"}, container={})
+        # Set up supporting mocks
+        mock__load_cwl_output.return_value = {'other_output_field': None}
+        # Test
+        actual_value = self.platform.get_task_output(task, 'some_output_field')
+        # Check results
+        self.assertIsNone(actual_value)
 
     @mock.patch("arvados.collection.Collection")
     def test_get_task_output_filename_single_file(self, mock_collection):

--- a/tests/test_arvados_platform.py
+++ b/tests/test_arvados_platform.py
@@ -45,6 +45,18 @@ class TestArvadosPlaform(unittest.TestCase):
         # Check results
         self.assertIsNone(actual_value)
 
+    @mock.patch('cwl_platform.arvados_platform.ArvadosPlatform._load_cwl_output')
+    def test_get_task_output_optional_step_file_missing(self, mock__load_cwl_output):
+        ''' Test that get_task_output can handle cases when an optional step file is missing in cwl_output '''
+        # Set up test parameters
+        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"}, container={})
+        # Set up supporting mocks
+        mock__load_cwl_output.return_value = {'some_output_field': None}
+        # Test
+        actual_value = self.platform.get_task_output(task, 'some_output_field')
+        # Check results
+        self.assertIsNone(actual_value)
+
     @mock.patch("arvados.collection.Collection")
     def test_get_task_output_filename_single_file(self, mock_collection):
         ''' Test get_task_output_filename method with single dictionary output '''


### PR DESCRIPTION
Please see Issue #57 

In get_output_task in arvados_platform.py if an output is missing for e.g. it could be an optional output from an optional step of the pipeline we get an error:

File "/scratch/mount1/06-RNA-Seq-pipeline-solve-issues/RNA-Seq-Launcher/launcher/src/launcher.py", line 507, in do_work
outputs = construct_output_list(platform, args.reference_model, merge_task)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/scratch/mount1/06-RNA-Seq-pipeline-solve-issues/RNA-Seq-Launcher/launcher/src/launcher.py", line 34, in construct_output_list
source_file = platform.get_task_output(merge_task, output_field)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/ec2-user/.pyenv/versions/RNASeq_pipeline_solve_issues_py3.11.0/lib/python3.11/site-packages/cwl_platform/arvados_platform.py", line 434, in get_task_output
if 'location' in output_field:
^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable

Therefore, we need to add a check in get_output_task if the output_field is None we return None.

In SevenBridges, if the file is missing it is already returned as None.