### PR TITLE
Add deprecation comment

### DIFF
--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -426,7 +426,11 @@ class ArvadosPlatform(Platform):
         return list(cwl_output.keys())
 
     def get_task_output_filename(self, task: ArvadosTask, output_name):
-        ''' Retrieve the output field of the task and return filename'''
+        '''
+        Retrieve the output field of the task and return filename
+        NOTE: This method is deprecated as of v0.2.5 of PAML.  Will be removed in v1.0.
+        '''
+        self.logger.warning("get_task_output_filename to be DEPRECATED (as of v0.2.5), use get_task_output instead.")
         cwl_output_collection = arvados.collection.Collection(task.container_request['output_uuid'],
                                                               api_client=self.api,
                                                               keep_client=self.keep_client)

--- a/src/cwl_platform/base_platform.py
+++ b/src/cwl_platform/base_platform.py
@@ -127,7 +127,10 @@ class Platform(ABC):
 
     @abstractmethod
     def get_task_output_filename(self, task, output_name):
-        ''' Retrieve the output field of the task and return filename'''
+        '''
+        Retrieve the output field of the task and return filename
+        NOTE: This method is deprecated as of v0.2.5 of PAML.  Will be removed in v1.0.
+        '''
 
     @abstractmethod
     def get_tasks_by_name(self, project, task_name):

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -383,7 +383,10 @@ class SevenBridgesPlatform(Platform):
         return list(task.outputs.keys())
 
     def get_task_output_filename(self, task: sevenbridges.Task, output_name):
-        ''' Retrieve the output field of the task and return filename'''
+        '''
+        Retrieve the output field of the task and return filename
+        NOTE: This method is deprecated as of v0.2.5 of PAML.  Will be removed in v1.0.
+        '''
         task = self.api.tasks.get(id=task.id)
         if output_name in task.outputs:
             if isinstance(task.outputs[output_name], list):


### PR DESCRIPTION
get_task_output and get_task_output_filename are fairly duplicative and I'd like to remove one in favor of the other.   The checks for a valid task output is not consistent between Arvados and SevenBridges either.  I'm adding a notice of deprecation to get_task_output_filename in favor of using get_task_output instead.
