### PR TITLE
Modify get_task_input to handle list of files

### DIFF
--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -600,10 +600,13 @@ class ArvadosPlatform(Platform):
     def get_task_input(self, task, input_name):
         ''' Retrieve the input field of the task '''
         if input_name in task.container_request['properties']['cwl_input']:
-            input_field = task.container_request['properties']['cwl_input'][input_name]
-            if 'location' in input_field:
-                return input_field['location']
-            return input_field
+            input_value = task.container_request['properties']['cwl_input'][input_name]
+            if isinstance(input_value, dict) and 'location' in input_value:
+                return input_value['location']
+            if (isinstance(input_value, list) and
+                all(isinstance(input, dict) and 'location' in input for input in input_value)):
+                return [input['location'] for input in input_value]
+            return input_value
         raise ValueError(f"Could not find input {input_name} in task {task.container_request['uuid']}")
 
     def get_task_state(self, task: ArvadosTask, refresh=False):

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -510,9 +510,13 @@ class SevenBridgesPlatform(Platform):
 
     def get_task_input(self, task: sevenbridges.Task, input_name):
         ''' Retrieve the input field of the task '''
-        if isinstance(task.inputs[input_name], sevenbridges.File):
-            return task.inputs[input_name].id
-        return task.inputs[input_name]
+        input_value = task.inputs[input_name]
+        if isinstance(input_value, sevenbridges.File):
+            return input_value.id
+        if (isinstance(input_value, list) and
+            all(isinstance(element, sevenbridges.File) for element in input_value)):
+            return [element.id for element in input_value]
+        return input_value
 
     def get_task_state(self, task: sevenbridges.Task, refresh=False):
         ''' Get workflow/task state '''

--- a/tests/test_arvados_platform.py
+++ b/tests/test_arvados_platform.py
@@ -84,6 +84,29 @@ class TestArvadosPlaform(unittest.TestCase):
 
         self.assertEqual(actual_result, test_location)
 
+    def test_get_task_input_list_of_file_obj(self):
+        '''
+        Test get_task_input method with a single File object
+        '''
+        test_location1 = "keep:a1ed2cf316addc5e751f1560ac6cc260+238884/somefile1.txt"
+        test_location2 = "keep:a1ed2cf316addc5e751f1560ac6cc260+238884/somefile2.txt"
+
+        mock_task = MagicMock()
+        mock_task.container_request = {
+            'properties': {
+                'cwl_input': {
+                    'input1': [
+                        {'location': test_location1},
+                        {'location': test_location2}
+                    ]
+                }
+            }
+        }
+
+        actual_result = self.platform.get_task_input(mock_task, 'input1')
+
+        self.assertEqual(actual_result, [test_location1, test_location2])
+
     @mock.patch('cwl_platform.arvados_platform.ArvadosPlatform._load_cwl_output')
     def test_get_task_output(self, mock__load_cwl_output):
         ''' Test that get_task_output can handle cases when the cwl_output is {} '''

--- a/tests/test_arvados_platform.py
+++ b/tests/test_arvados_platform.py
@@ -44,7 +44,7 @@ class TestArvadosPlaform(unittest.TestCase):
         self.platform.connect()
         self.assertTrue(self.platform.connected)
 
-    def test_get_task_input_non_file_object(self):
+    def test_get_task_input_non_file_obj(self):
         '''
         Test get_task_input method where the input is not a File object (e.g. string)
         '''
@@ -62,6 +62,27 @@ class TestArvadosPlaform(unittest.TestCase):
         actual_result = self.platform.get_task_input(mock_task, 'input1')
 
         self.assertEqual(actual_result, test_value)
+
+    def test_get_task_input_file_obj(self):
+        '''
+        Test get_task_input method with a single File object
+        '''
+        test_location = "keep:a1ed2cf316addc5e751f1560ac6cc260+238884/somefile.txt"
+
+        mock_task = MagicMock()
+        mock_task.container_request = {
+            'properties': {
+                'cwl_input': {
+                    'input1': {
+                        'location': test_location,
+                    }
+                }
+            }
+        }
+
+        actual_result = self.platform.get_task_input(mock_task, 'input1')
+
+        self.assertEqual(actual_result, test_location)
 
     @mock.patch('cwl_platform.arvados_platform.ArvadosPlatform._load_cwl_output')
     def test_get_task_output(self, mock__load_cwl_output):

--- a/tests/test_arvados_platform.py
+++ b/tests/test_arvados_platform.py
@@ -44,6 +44,25 @@ class TestArvadosPlaform(unittest.TestCase):
         self.platform.connect()
         self.assertTrue(self.platform.connected)
 
+    def test_get_task_input_non_file_object(self):
+        '''
+        Test get_task_input method where the input is not a File object (e.g. string)
+        '''
+        test_value = "test_value"
+
+        mock_task = MagicMock()
+        mock_task.container_request = {
+            'properties': {
+                'cwl_input': {
+                    'input1': test_value
+                }
+            }
+        }
+
+        actual_result = self.platform.get_task_input(mock_task, 'input1')
+
+        self.assertEqual(actual_result, test_value)
+
     @mock.patch('cwl_platform.arvados_platform.ArvadosPlatform._load_cwl_output')
     def test_get_task_output(self, mock__load_cwl_output):
         ''' Test that get_task_output can handle cases when the cwl_output is {} '''

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -160,6 +160,21 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         # Assert
         task.run.assert_called_once_with()
 
+    def test_get_task_input(self):
+        '''
+        Test get_task_input method with a single File object
+        '''
+        test_file_id = 'a1234'
+
+        mock_file = MagicMock(spec=sevenbridges.File)
+        mock_file.id = test_file_id
+        mock_task = MagicMock(spec=sevenbridges.Task)
+        mock_task.inputs = {'input1': mock_file}
+
+        actual_result = self.platform.get_task_input(mock_task, 'input1')
+
+        self.assertEqual(actual_result, test_file_id)
+
     @mock.patch('cwl_platform.sevenbridges_platform.SevenBridgesPlatform._find_or_create_path')
     def test_upload_file(self, mock_find_or_create_path):
         '''

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -160,24 +160,9 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         # Assert
         task.run.assert_called_once_with()
 
-    def test_get_task_input_file_obj(self):
-        '''
-        Test get_task_input method with a single File object
-        '''
-        test_file_id = 'a1234'
-
-        mock_file = MagicMock(spec=sevenbridges.File)
-        mock_file.id = test_file_id
-        mock_task = MagicMock(spec=sevenbridges.Task)
-        mock_task.inputs = {'input1': mock_file}
-
-        actual_result = self.platform.get_task_input(mock_task, 'input1')
-
-        self.assertEqual(actual_result, test_file_id)
-
     def test_get_task_input_non_file_obj(self):
         '''
-        Test get_task_input method with a single File object
+        Test get_task_input method where the input is not a File object (e.g. string)
         '''
         test_value = "test_value"
 
@@ -187,6 +172,36 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         actual_result = self.platform.get_task_input(mock_task, 'input1')
 
         self.assertEqual(actual_result, test_value)
+
+    def test_get_task_input_file_obj(self):
+        '''
+        Test get_task_input method with a single File object
+        '''
+        test_file_id = 'a1234'
+
+        mock_file = MagicMock(spec=sevenbridges.File, id = test_file_id)
+        mock_task = MagicMock(spec=sevenbridges.Task)
+        mock_task.inputs = {'input1': mock_file}
+
+        actual_result = self.platform.get_task_input(mock_task, 'input1')
+
+        self.assertEqual(actual_result, test_file_id)
+
+    def test_get_task_input_list_of_file_obj(self):
+        '''
+        Test get_task_input method with a list of File objects
+        '''
+        test_file1_id = 'a1234'
+        test_file2_id = 'b2345'
+
+        mock_file1 = MagicMock(spec=sevenbridges.File, id = test_file1_id)
+        mock_file2 = MagicMock(spec=sevenbridges.File, id = test_file2_id)
+        mock_task = MagicMock(spec=sevenbridges.Task)
+        mock_task.inputs = {'input1': [mock_file1, mock_file2]}
+
+        actual_result = self.platform.get_task_input(mock_task, 'input1')
+
+        self.assertEqual(actual_result, [test_file1_id, test_file2_id])
 
     @mock.patch('cwl_platform.sevenbridges_platform.SevenBridgesPlatform._find_or_create_path')
     def test_upload_file(self, mock_find_or_create_path):

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -160,7 +160,7 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         # Assert
         task.run.assert_called_once_with()
 
-    def test_get_task_input(self):
+    def test_get_task_input_file_obj(self):
         '''
         Test get_task_input method with a single File object
         '''
@@ -174,6 +174,19 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         actual_result = self.platform.get_task_input(mock_task, 'input1')
 
         self.assertEqual(actual_result, test_file_id)
+
+    def test_get_task_input_non_file_obj(self):
+        '''
+        Test get_task_input method with a single File object
+        '''
+        test_value = "test_value"
+
+        mock_task = MagicMock(spec=sevenbridges.Task)
+        mock_task.inputs = {'input1': test_value}
+
+        actual_result = self.platform.get_task_input(mock_task, 'input1')
+
+        self.assertEqual(actual_result, test_value)
 
     @mock.patch('cwl_platform.sevenbridges_platform.SevenBridgesPlatform._find_or_create_path')
     def test_upload_file(self, mock_find_or_create_path):


### PR DESCRIPTION
when an input is a File, get_task_input returns the file id (SBG) or file location (Arvados) to account for differences between the platforms. However, when the input is a list of Files, we return the underlying File objects, leading to a divergence in behavior and preventing the launcher from checking that a previous task has the same inputs for reuse.

this PR handles lists of Files by returning a list of file ids (SBG) or file locations (Arvados) to remain consistent and platform agnostic.