### PR TITLE
Feature check if task identical

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ venv/
 .idea/
 .vscode/
 *.log
+build
 
 # Ignore code coverage files
 .coverage

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install: build
 	python3 -m pip install --upgrade dist/*.whl
 
 test:
-	PYTHONPATH=src coverage run --source=src -m pytest -v
+	PYTHONPATH=src coverage run --source=src -m pytest -v --log-cli-level=INFO
 	coverage report
 	coverage html
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 chardet
 smart_open
-arvados-python-client==3.0.0
+arvados-python-client==2.7.4
 sevenbridges-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 chardet
 smart_open
-arvados-python-client<3.0.0
+arvados-python-client==3.1.1
 sevenbridges-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 chardet
 smart_open
-arvados-python-client==2.7.4
+arvados-python-client==3.1.1
 sevenbridges-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 chardet
 smart_open
-arvados-python-client==3.1.1
+arvados-python-client==3.0.0
 sevenbridges-python

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -446,7 +446,7 @@ class ArvadosPlatform(Platform):
                 source_collection_uuid = output_file['source'].split(':')[1].split('/')[0]
                 source_file = '/'.join(output_file['source'].split(':')[1].split('/')[1:])
                 source_collection = arvados.collection.Collection(source_collection_uuid,
-                                                                  pi_client=self.api)
+                                                                  api_client=self.api)
 
                 # Copy the file
                 outputs_collection.copy(source_file, target_path=output_file['destination'],
@@ -649,9 +649,9 @@ class ArvadosPlatform(Platform):
             task.container_request = arvados.api().container_requests().get( # pylint: disable=not-callable
                 uuid = task.container_request['uuid']
             ).execute()
-            task.container = arvados.api().containers().get(
+            task.container = arvados.api().containers().get( # pylint: disable=not-callable
                 uuid = task.container_request['container_uuid']
-                ).execute() # pylint: disable=not-callable
+                ).execute()
 
         if task.container['exit_code'] == 0:
             return 'Complete'

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -749,13 +749,10 @@ class ArvadosPlatform(Platform):
             )
 
         tasks = []
-        container_requests = list(arvados.util.keyset_list_all(
+        for container_request in arvados.util.keyset_list_all(
             self.api.container_requests().list,
             filters=filters
-        ))
-        self.logger.info("Found %d container requests: %s",
-                         len(container_requests), container_requests)
-        for container_request in container_requests:
+        ):
             # Get the container
             container = self.api.containers().get(
                 uuid=container_request['container_uuid']).execute()

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -767,10 +767,15 @@ class ArvadosPlatform(Platform):
             else:
                 if container_request['name'] == task_name:
                     # Check if the task inputs match the inputs_to_compare
+                    task_inputs = None
                     if 'properties' in container_request and \
                         'cwl_input' in container_request['properties']:
                         task_inputs = container_request['properties']['cwl_input']
+                    elif 'mounts' in container and \
+                        '/var/lib/cwl/cwl.input.json' in container['mounts']:
+                        task_inputs = container['mounts']['/var/lib/cwl/cwl.input.json']['content']
 
+                    if task_inputs:
                         # Check if all inputs_to_compare are in task_inputs and have the same values
                         inputs_match = True
                         for input_name, input_value in inputs_to_compare.items():

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -790,10 +790,14 @@ class ArvadosPlatform(Platform):
                         return True
                 return False
             
-            # For other dictionaries, check if all keys in input_to_compare are in task_input
-            # and have the same values
+            # For other dictionaries, check if both dictionaries have the same keys
+            # and the same values for those keys
+            if set(task_input.keys()) != set(input_to_compare.keys()):
+                return False
+                
+            # Now check that all values match
             for key, value in input_to_compare.items():
-                if key not in task_input or not self._compare_inputs(task_input[key], value):
+                if not self._compare_inputs(task_input[key], value):
                     return False
             return True
         

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -749,10 +749,13 @@ class ArvadosPlatform(Platform):
             )
 
         tasks = []
-        for container_request in arvados.util.keyset_list_all(
+        container_requests = arvados.util.keyset_list_all(
             self.api.container_requests().list,
             filters=filters
-        ):
+        )
+        self.logger.info("Found %d container requests: %s",
+                         len(container_requests), container_requests)
+        for container_request in container_requests:
             # Get the container
             container = self.api.containers().get(
                 uuid=container_request['container_uuid']).execute()

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -749,10 +749,10 @@ class ArvadosPlatform(Platform):
             )
 
         tasks = []
-        container_requests = arvados.util.keyset_list_all(
+        container_requests = list(arvados.util.keyset_list_all(
             self.api.container_requests().list,
             filters=filters
-        )
+        ))
         self.logger.info("Found %d container requests: %s",
                          len(container_requests), container_requests)
         for container_request in container_requests:

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -691,11 +691,17 @@ class ArvadosPlatform(Platform):
                 return cwl_output[output_name]['basename']
         raise ValueError(f"Output {output_name} does not exist for task {task.container_request['uuid']}.")
 
-    def get_tasks_by_name(self, project, task_name=None): # -> list(ArvadosTask):
+    def get_tasks_by_name(self,
+                          project:str,
+                          task_name:str=None,
+                          inputs_to_compare:dict=None): # -> list(ArvadosTask):
         '''
-        Get all processes/tasks in a project with a specified name
+        Get all processes/tasks in a project with a specified name, or all tasks
+        if no name is specified. Optionally, compare task inputs to ensure
+        equivalency (eg for reuse).
         :param project: The project to search
         :param task_name: The name of the process to search for (if None return all tasks)
+        :param inputs_to_compare: Inputs to compare to ensure task equivalency
         :return: List of tasks
         '''
         # We must add priority>0 filter so we do not capture Cancelled jobs as Queued jobs.

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -737,23 +737,23 @@ class ArvadosPlatform(Platform):
                         inputs_match = True
                         for input_name, input_value in inputs_to_compare.items():
                             if input_name not in task_inputs:
-                                self.logger.info("Input %s not found in task %s", input_name, container_request['name'])
+                                self.logger.info("Input %s not found in task %s", input_name, container_request['uuid'])
                                 inputs_match = False
                                 break
                             
                             # Compare the input values
                             if not self._compare_inputs(task_inputs[input_name], input_value):
                                 self.logger.info("Task %s input %s does not match: %s vs query %s",
-                                                container_request['name'], input_name,
+                                                container_request['uuid'], input_name,
                                                 task_inputs[input_name], input_value)
                                 inputs_match = False
                                 break
                         
                         if inputs_match:
-                            self.logger.info("Task %s matches inputs", container_request['name'])
+                            self.logger.info("Task %s matches inputs", container_request['uuid'])
                             tasks.append(task)
                     else:
-                        self.logger.info("Task %s has no cwl_input property", container_request['name'])
+                        self.logger.info("Task %s has no cwl_input property", container_request['uuid'])
         return tasks
         
     def _compare_inputs(self, task_input, input_to_compare):

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -74,7 +74,9 @@ class ArvadosTaskEncoder(json.JSONEncoder):
         return super().default(o)
 
 class StreamFileReader(arvados.arvfile.ArvadosFileReader):
-    ''' This class replaces the deprecated StreamFileReader that existed in Arvados prior to 2.7.4 '''
+    '''
+    This class replaces the deprecated StreamFileReader that existed in Arvados prior to 2.7.4
+    '''
     class _NameAttribute(str):
         # The Python file API provides a plain .name attribute.
         # Older SDK provided a name() method.
@@ -123,7 +125,8 @@ class ArvadosPlatform(Platform):
 
     def _get_files_list_in_collection(self, collection_uuid, subdirectory_path=None):
         '''
-        Get list of files in collection, if subdirectory_path is provided, return only files in that subdirectory.
+        Get list of files in collection, if subdirectory_path is provided, return
+        only files in that subdirectory.
 
         :param collection_uuid: uuid of the collection
         :param subdirectory_path: subdirectory path to filter files in the collection
@@ -132,7 +135,9 @@ class ArvadosPlatform(Platform):
         the_col = arvados.collection.CollectionReader(manifest_locator_or_text=collection_uuid)
         file_list = self._all_files(the_col)
         if subdirectory_path:
-            return [fl for fl in file_list if os.path.basename(fl.stream_name()) == subdirectory_path]
+            return [fl for fl in file_list if (
+                os.path.basename(fl.stream_name()) == subdirectory_path
+                )]
         return list(file_list)
 
     def _load_cwl_output(self, task: ArvadosTask):
@@ -171,10 +176,12 @@ class ArvadosPlatform(Platform):
             ["name", "=", collection_name]
             ]).execute()
         if len(search_result['items']) > 0:
-            self.logger.debug("Found source collection %s in project %s", collection_name, project["uuid"])
+            self.logger.debug("Found source collection %s in project %s",
+                              collection_name, project["uuid"])
             return search_result['items'][0]
 
-        self.logger.error("Source collection %s not found in project %s", collection_name, project["uuid"])
+        self.logger.error("Source collection %s not found in project %s",
+                          collection_name, project["uuid"])
         return None
 
     # File methods
@@ -195,7 +202,8 @@ class ArvadosPlatform(Platform):
             return None
 
         # 2. Get the destination project collection
-        destination_collection = self._lookup_collection_from_foldername(destination_project, source_folder)
+        destination_collection = self._lookup_collection_from_foldername(
+            destination_project, source_folder)
         if not destination_collection:
             destination_collection = self.api.collections().create(body={
                 "owner_uuid": destination_project["uuid"],
@@ -206,7 +214,8 @@ class ArvadosPlatform(Platform):
         # Copy the files from the reference project to the destination project
         self.logger.debug("Get list of files in source collection, %s", source_collection["uuid"])
         source_files = self._get_files_list_in_collection(source_collection["uuid"])
-        self.logger.debug("Getting list of files in destination collection, %s", destination_collection["uuid"])
+        self.logger.debug("Getting list of files in destination collection, %s",
+                          destination_collection["uuid"])
         destination_files = self._get_files_list_in_collection(destination_collection["uuid"])
 
         source_collection = arvados.collection.Collection(source_collection["uuid"])
@@ -216,7 +225,9 @@ class ArvadosPlatform(Platform):
             source_path = f"{source_file.stream_name()}/{source_file.name()}"
             if source_path not in [f"{destination_file.stream_name()}/{destination_file.name()}"
                                 for destination_file in destination_files]:
-                target_collection.copy(source_path, target_path=source_path, source_collection=source_collection)
+                target_collection.copy(source_path,
+                                       target_path=source_path,
+                                       source_collection=source_collection)
         target_collection.save()
 
         self.logger.debug("Done copying folder.")
@@ -282,7 +293,8 @@ class ArvadosPlatform(Platform):
         dest_file = os.path.join(dest_folder, os.path.basename(file))
         collection_uuid, file_path = find_collection_file_path(file)
 
-        c = arvados.collection.CollectionReader(manifest_locator_or_text=collection_uuid, api_client=self.api)
+        c = arvados.collection.CollectionReader(manifest_locator_or_text=collection_uuid,
+                                                api_client=self.api)
         with c.open(file_path, "rb") as reader:
             with open(dest_file, "wb") as writer:
                 content = reader.read(128*1024)
@@ -343,8 +355,9 @@ class ArvadosPlatform(Platform):
         else:
             raise ValueError(f"Collection {collection_name} not found in project {project['uuid']}")
 
-        # Do we need to check for the file in the collection?  That could add a lot of overhead to query the collection
-        # for the file.  Lets see if this comes up before implementing it.
+        # Do we need to check for the file in the collection?
+        # That could add a lot of overhead to query the collection for the file.
+        # Lets see if this comes up before implementing it.
         return f"keep:{collection['portable_data_hash']}/{'/'.join(folder_tree[1:])}"
 
     def get_folder_id(self, project, folder_path):
@@ -416,13 +429,15 @@ class ArvadosPlatform(Platform):
             outputs_collection = self.api.collections().create(body={
                 "owner_uuid": project["uuid"],
                 "name": output_collection_name}).execute()
-        outputs_collection = arvados.collection.Collection(outputs_collection['uuid'], api_client=self.api)
+        outputs_collection = arvados.collection.Collection(outputs_collection['uuid'],
+                                                           api_client=self.api)
 
         with outputs_collection.open("sources.txt", "a+") as sources:
             copied_outputs = [n.strip() for n in sources.readlines()]
 
             for output_file in output_files:
-                self.logger.info("Staging output file %s -> %s", output_file['source'], output_file['destination'])
+                self.logger.info("Staging output file %s -> %s",
+                                 output_file['source'], output_file['destination'])
                 if output_file['source'] in copied_outputs:
                     continue
 
@@ -430,7 +445,8 @@ class ArvadosPlatform(Platform):
                 #keep:asdf-asdf-asdf/some/file.txt
                 source_collection_uuid = output_file['source'].split(':')[1].split('/')[0]
                 source_file = '/'.join(output_file['source'].split(':')[1].split('/')[1:])
-                source_collection = arvados.collection.Collection(source_collection_uuid, api_client=self.api)
+                source_collection = arvados.collection.Collection(source_collection_uuid,
+                                                                  pi_client=self.api)
 
                 # Copy the file
                 outputs_collection.copy(source_file, target_path=output_file['destination'],
@@ -442,12 +458,14 @@ class ArvadosPlatform(Platform):
         except googleapiclient.errors.HttpError as exc:
             self.logger.error("Failed to save output files: %s", exc)
 
-    def upload_file(self, filename, project, dest_folder=None, destination_filename=None, overwrite=False): # pylint: disable=too-many-arguments
+    def upload_file(self, filename, project, dest_folder=None, destination_filename=None,
+                    overwrite=False): # pylint: disable=too-many-arguments
         '''
         Upload a local file to project 
         :param filename: filename of local file to be uploaded.
         :param project: project that the file is uploaded to.
-        :param dest_folder: The target path to the folder that file will be uploaded to. None will upload to root.
+        :param dest_folder: The target path to the folder that file will be uploaded to.
+        None will upload to root.
         :param destination_filename: File name after uploaded to destination folder.
         :param overwrite: Overwrite the file if it already exists.
         :return: ID of uploaded file.
@@ -509,7 +527,8 @@ class ArvadosPlatform(Platform):
         :param destination_project: The project to copy the workflow to
         :return: The workflow that was copied or exists in the destination project
         '''
-        self.logger.debug("Copying workflow %s to project %s", src_workflow, destination_project["uuid"])
+        self.logger.debug("Copying workflow %s to project %s",
+                          src_workflow, destination_project["uuid"])
         # Get the workflow we want to copy
         try:
             workflow = self.api.workflows().get(uuid=src_workflow).execute()
@@ -532,12 +551,14 @@ class ArvadosPlatform(Platform):
             ["name", "like", f"{wf_name}%"]
             ]).execute()
         if len(existing_workflows["items"]):
-            self.logger.debug("Workflow %s already exists in project %s", wf_name, destination_project["uuid"])
+            self.logger.debug("Workflow %s already exists in project %s",
+                              wf_name, destination_project["uuid"])
             # Return existing matching workflow
             return existing_workflows["items"][0]
 
         # Workflow does not exist in project, so copy it
-        self.logger.debug("Workflow %s does not exist in project %s, copying", wf_name, destination_project["uuid"])
+        self.logger.debug("Workflow %s does not exist in project %s, copying",
+                          wf_name, destination_project["uuid"])
         workflow['owner_uuid'] = destination_project['uuid']
         del workflow['uuid']
         copied_workflow = self.api.workflows().create(body=workflow).execute()
@@ -554,7 +575,9 @@ class ArvadosPlatform(Platform):
         destination_workflows = self.get_workflows(destination_project)
         # Copy the workflow if it doesn't already exist in the destination project
         for workflow in reference_workflows["items"]:
-            if workflow["name"] not in [workflow["name"] for workflow in destination_workflows["items"]]:
+            if workflow["name"] not in [
+                workflow["name"]for workflow in destination_workflows["items"]
+            ]:
                 workflow['owner_uuid'] = destination_project["uuid"]
                 del workflow['uuid']
                 destination_workflows.append(self.api.workflows().create(body=workflow).execute())
@@ -607,15 +630,17 @@ class ArvadosPlatform(Platform):
                 all(isinstance(input, dict) and 'location' in input for input in input_value)):
                 return [input['location'] for input in input_value]
             return input_value
-        raise ValueError(f"Could not find input {input_name} in task {task.container_request['uuid']}")
+        raise ValueError(
+            f"Could not find input {input_name} in task {task.container_request['uuid']}"
+        )
 
     def get_task_state(self, task: ArvadosTask, refresh=False):
         '''
         Get workflow/task state
 
         :param project: The project to search
-        :param task: The task to search for. Task is an ArvadosTask containing a container_request_uuid and
-            container dictionary.
+        :param task: The task to search for. Task is an ArvadosTask containing
+        a container_request_uuid and container dictionary.
         :return: The state of the task (Queued, Running, Complete, Failed, Cancelled)
         '''
         if refresh:
@@ -624,7 +649,9 @@ class ArvadosPlatform(Platform):
             task.container_request = arvados.api().container_requests().get( # pylint: disable=not-callable
                 uuid = task.container_request['uuid']
             ).execute()
-            task.container = arvados.api().containers().get(uuid = task.container_request['container_uuid']).execute() # pylint: disable=not-callable
+            task.container = arvados.api().containers().get(
+                uuid = task.container_request['container_uuid']
+                ).execute() # pylint: disable=not-callable
 
         if task.container['exit_code'] == 0:
             return 'Complete'
@@ -658,7 +685,9 @@ class ArvadosPlatform(Platform):
             for output in output_field:
                 if 'location' in output:
                     output_file = output['location']
-                    output_files.append(f"keep:{task.container_request['output_uuid']}/{output_file}")
+                    output_files.append(
+                        f"keep:{task.container_request['output_uuid']}/{output_file}"
+                        )
             return output_files
 
         if 'location' in output_field:
@@ -678,7 +707,9 @@ class ArvadosPlatform(Platform):
         Retrieve the output field of the task and return filename
         NOTE: This method is deprecated as of v0.2.5 of PAML.  Will be removed in v1.0.
         '''
-        self.logger.warning("get_task_output_filename to be DEPRECATED (as of v0.2.5), use get_task_output instead.")
+        self.logger.warning(
+            "get_task_output_filename to be DEPRECATED (as of v0.2.5),use get_task_output instead."
+        )
         cwl_output_collection = arvados.collection.Collection(task.container_request['output_uuid'],
                                                               api_client=self.api,
                                                               keep_client=self.keep_client)
@@ -689,7 +720,9 @@ class ArvadosPlatform(Platform):
                 return [output['basename'] for output in cwl_output[output_name]]
             if isinstance(cwl_output[output_name], dict):
                 return cwl_output[output_name]['basename']
-        raise ValueError(f"Output {output_name} does not exist for task {task.container_request['uuid']}.")
+        raise ValueError(
+            f"Output {output_name} does not exist for task {task.container_request['uuid']}."
+        )
 
     def get_tasks_by_name(self,
                           project:str,
@@ -705,8 +738,8 @@ class ArvadosPlatform(Platform):
         :return: List of tasks
         '''
         # We must add priority>0 filter so we do not capture Cancelled jobs as Queued jobs.
-        # According to Curii, 'Cancelled' on the UI = 'Queued' with priority=0, we are not interested in Cancelled
-        # jobs here anyway, we will submit the job again
+        # According to Curii, 'Cancelled' on the UI = 'Queued' with priority=0,
+        # we are not interested in Cancelled jobs here anyway, we will submit the job again
         filters = [
             ['owner_uuid', '=', project['uuid']], ['priority', '>', 0]
         ]
@@ -721,26 +754,31 @@ class ArvadosPlatform(Platform):
             filters=filters
         ):
             # Get the container
-            container = self.api.containers().get(uuid=container_request['container_uuid']).execute()
+            container = self.api.containers().get(
+                uuid=container_request['container_uuid']).execute()
             task = ArvadosTask(container_request, container)
-            
+
             if inputs_to_compare is None:
                 if task_name is None or container_request['name'] == task_name:
                     tasks.append(task)
             else:
                 if container_request['name'] == task_name:
                     # Check if the task inputs match the inputs_to_compare
-                    if 'properties' in container_request and 'cwl_input' in container_request['properties']:
+                    if 'properties' in container_request and \
+                        'cwl_input' in container_request['properties']:
                         task_inputs = container_request['properties']['cwl_input']
-                        
+
                         # Check if all inputs_to_compare are in task_inputs and have the same values
                         inputs_match = True
                         for input_name, input_value in inputs_to_compare.items():
                             if input_name not in task_inputs:
-                                self.logger.info("Input %s not found in task %s", input_name, container_request['uuid'])
+                                self.logger.info(
+                                    "Input %s not found in task %s",
+                                    input_name, container_request['uuid']
+                                )
                                 inputs_match = False
                                 break
-                            
+
                             # Compare the input values
                             if not self._compare_inputs(task_inputs[input_name], input_value):
                                 self.logger.info("Task %s input %s does not match: %s vs query %s",
@@ -748,14 +786,16 @@ class ArvadosPlatform(Platform):
                                                 task_inputs[input_name], input_value)
                                 inputs_match = False
                                 break
-                        
+
                         if inputs_match:
                             self.logger.info("Task %s matches inputs", container_request['uuid'])
                             tasks.append(task)
                     else:
-                        self.logger.info("Task %s has no cwl_input property", container_request['uuid'])
+                        self.logger.info(
+                            "Task %s has no cwl_input property", container_request['uuid']
+                        )
         return tasks
-        
+
     def _compare_inputs(self, task_input, input_to_compare):
         """
         Compare a task input to an input to compare
@@ -770,48 +810,50 @@ class ArvadosPlatform(Platform):
                 if 'location' in task_input and 'path' in input_to_compare:
                     return task_input['location'] == input_to_compare['path']
                 return False
-            
+
             # For Directory objects, compare the location/path and listing if available
             if 'class' in input_to_compare and input_to_compare['class'] == 'Directory':
                 if 'location' in task_input and 'path' in input_to_compare:
                     if task_input['location'] != input_to_compare['path']:
                         return False
-                    
+
                     # If listing is available, compare it
                     if 'listing' in task_input and 'listing' in input_to_compare:
                         if len(task_input['listing']) != len(input_to_compare['listing']):
                             return False
-                        
+
                         # Compare each item in the listing
-                        for task_item, compare_item in zip(task_input['listing'], input_to_compare['listing']):
+                        for task_item, compare_item in zip(
+                            task_input['listing'], input_to_compare['listing']
+                            ):
                             if not self._compare_inputs(task_item, compare_item):
                                 return False
-                        
+
                         return True
                 return False
-            
+
             # For other dictionaries, check if both dictionaries have the same keys
             # and the same values for those keys
             if set(task_input.keys()) != set(input_to_compare.keys()):
                 return False
-                
+
             # Now check that all values match
             for key, value in input_to_compare.items():
                 if not self._compare_inputs(task_input[key], value):
                     return False
             return True
-        
+
         # If the inputs are lists, compare them item by item
         elif isinstance(task_input, list) and isinstance(input_to_compare, list):
             if len(task_input) != len(input_to_compare):
                 return False
-            
+
             # Compare each item in the list
             for task_item, compare_item in zip(task_input, input_to_compare):
                 if not self._compare_inputs(task_item, compare_item):
                     return False
             return True
-        
+
         # For simple values, compare them directly
         else:
             return task_input == input_to_compare
@@ -882,7 +924,8 @@ class ArvadosPlatform(Platform):
             with open(parameter_file.name, mode='w', encoding="utf-8") as fout:
                 json.dump(parameters, fout)
 
-            use_spot_instance = execution_settings.get('use_spot_instance', True) if execution_settings else True
+            use_spot_instance = execution_settings.get(
+                'use_spot_instance', True) if execution_settings else True
             if use_spot_instance:
                 cmd_spot_instance = "--enable-preemptible"
             else:
@@ -1024,7 +1067,9 @@ class ArvadosPlatform(Platform):
         :param project: platform project
         :param permission: permission (permission="read|write|execute|admin")
         """
-        a_permission = 'can_manage' if permission=="admin" else 'can_write' if permission=="write" else 'can_read'
+        a_permission = 'can_manage' if permission=="admin" \
+            else 'can_write' if permission=="write" \
+            else 'can_read'
         self.api.links().create(body={"link": {
                                             "link_class": "permission",
                                             "name": a_permission,

--- a/src/cwl_platform/base_platform.py
+++ b/src/cwl_platform/base_platform.py
@@ -86,12 +86,14 @@ class Platform(ABC):
         '''
 
     @abstractmethod
-    def upload_file(self, filename, project, dest_folder=None, destination_filename=None, overwrite=False):
+    def upload_file(self, filename, project, dest_folder=None, destination_filename=None,
+                    overwrite=False):
         '''
         Upload a local file to project 
         :param filename: filename of local file to be uploaded.
         :param project: project that the file is uploaded to.
-        :param dest_folder: The target path to the folder that file will be uploaded to. None will upload to root.
+        :param dest_folder: The target path to the folder that file will be uploaded to.
+        None will upload to root.
         :param destination_filename: File name after uploaded to destination folder.
         :param overwrite: Overwrite the file if it already exists.
         :return: ID of uploaded file.

--- a/src/cwl_platform/base_platform.py
+++ b/src/cwl_platform/base_platform.py
@@ -172,11 +172,14 @@ class Platform(ABC):
         '''
 
     @abstractmethod
-    def get_tasks_by_name(self, project, task_name=None):
+    def get_tasks_by_name(self, project:str, task_name:str=None, inputs_to_compare:dict=None):
         '''
-        Get all processes/tasks in a project with a specified name
+        Get all processes/tasks in a project with a specified name, or all tasks
+        if no name is specified. Optionally, compare task inputs to ensure
+        equivalency (eg for reuse).
         :param project: The project to search
         :param task_name: The name of the process to search for (if None return all tasks)
+        :param inputs_to_compare: Inputs to compare to ensure task equivalency
         :return: List of tasks
         '''
 

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -599,8 +599,6 @@ class SevenBridgesPlatform(Platform):
                 self.logger.info("Platform object is a File, but input to compare is not")
                 return False
             else:
-                self.logger.info("Platform object is %s, input to compare is %s", platform_object.id,
-                                 input_to_compare.get("path"))
                 return platform_object.id == input_to_compare.get("path")
         elif isinstance(platform_object, list):
             if not isinstance(input_to_compare, list):

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -589,7 +589,8 @@ class SevenBridgesPlatform(Platform):
                 for platform_element, input_element in zip(
                     folder_contents,
                     input_to_compare['listing']):
-                    # this is intentionally sensitive to order
+                    # Directory inputs are sorted alphabetically, so while this check is order-
+                    # dependent, this is unlikely to differ in reality if elements are the same
                     if not self._compare_platform_object(platform_element, input_element):
                         self.logger.info("Platform object and input to compare were not the same: %s != %s",
                                          platform_element, input_element)
@@ -608,6 +609,7 @@ class SevenBridgesPlatform(Platform):
                 self.logger.info("Platform object and input to compare are not the same length")
                 return False
             for task_input, input_element in zip(platform_object, input_to_compare):
+                # this is intentionally sensitive to order
                 if not self._compare_platform_object(task_input, input_element):
                     self.logger.info("Platform object and input to compare were not the same: %s != %s",
                                      task_input, input_element)

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -6,7 +6,9 @@ import logging
 from typing import Any
 import sevenbridges
 from sevenbridges.errors import SbgError
-from sevenbridges.http.error_handlers import rate_limit_sleeper, maintenance_sleeper, general_error_sleeper
+from sevenbridges.http.error_handlers import (
+    rate_limit_sleeper, maintenance_sleeper, general_error_sleeper
+)
 
 from .base_platform import Platform
 
@@ -138,7 +140,8 @@ class SevenBridgesPlatform(Platform):
         sbg_destination_folder = self._find_or_create_path(destination_project, source_folder)
         # Copy the files from the reference project to the destination project
         reference_files = self._list_files_in_folder(project=source_project, folder=source_folder)
-        destination_files = list(self._list_files_in_folder(project=destination_project, folder=source_folder))
+        destination_files = list(self._list_files_in_folder(project=destination_project,
+                                                            folder=source_folder))
         for reference_file in reference_files:
             if reference_file.is_folder():
                 source_folder_rec = os.path.join(source_folder, reference_file.name)
@@ -230,7 +233,8 @@ class SevenBridgesPlatform(Platform):
 
     def _get_folder_contents(self, path, folder, filters):
         '''
-        Recusivelly returns all the files in a directory and subdirectories in a SevenBridges project.
+        Recusivelly returns all the files in a directory and subdirectories
+        in a SevenBridges project.
 
         :param path: path of file
         :param folder: SBG Folder reference
@@ -357,10 +361,14 @@ class SevenBridgesPlatform(Platform):
         if newtag not in target_file.tags:
             target_file.tags += [newtag]
             target_file.save()
-        if hasattr(target_file,'secondary_files') and target_file.secondary_files is not None:
+        if hasattr(target_file, 'secondary_files') and target_file.secondary_files is not None:
             secondary_files = target_file.secondary_files
             for secfile in secondary_files:
-                if isinstance(secfile,sevenbridges.models.file.File) and secfile.tags and newtag not in secfile.tags:
+                if (
+                    isinstance(secfile,sevenbridges.models.file.File) and
+                    secfile.tags and
+                    newtag not in secfile.tags
+                ):
                     secfile.tags += [newtag]
                     secfile.save()
 
@@ -386,7 +394,8 @@ class SevenBridgesPlatform(Platform):
         '''
         self.logger.warning("stage_output_files to be deprecated in future release.")
         for output_file in output_files:
-            self.logger.info("Staging output file %s -> %s", output_file['source'], output_file['destination'])
+            self.logger.info("Staging output file %s -> %s",
+                             output_file['source'], output_file['destination'])
             outfile = self.api.files.get(id=output_file['source'])
             if isinstance(outfile, sevenbridges.models.file.File):
                 if outfile.type == "file":
@@ -401,12 +410,14 @@ class SevenBridgesPlatform(Platform):
                         elif file.type == "folder":
                             self._add_tag_to_folder(file, "OUTPUT")
 
-    def upload_file(self, filename, project, dest_folder=None, destination_filename=None, overwrite=False): # pylint: disable=too-many-arguments
+    def upload_file(self, filename, project, dest_folder=None, destination_filename=None,
+                    overwrite=False): # pylint: disable=too-many-arguments
         '''
         Upload a local file to project 
         :param filename: filename of local file to be uploaded.
         :param project: project that the file is uploaded to.
-        :param dest_folder: The target path to the folder that file will be uploaded to. None will upload to root.
+        :param dest_folder: The target path to the folder that file will be uploaded to.
+        None will upload to root.
         :param destination_filename: File name after uploaded to destination folder.
         :param overwrite: Overwrite the file if it already exists.
         :return: ID of uploaded file.
@@ -473,7 +484,8 @@ class SevenBridgesPlatform(Platform):
         destination_workflows = list(destination_project.get_apps().all())
         # Copy the workflow if it doesn't already exist in the destination project
         for workflow in reference_workflows:
-            # NOTE This is also copies archived apps.  How do we filter those out?  Asked Nikola, waiting for response.
+            # NOTE This is also copies archived apps.  How do we filter those out?
+            # Asked Nikola, waiting for response.
             if workflow.name not in [wf.name for wf in destination_workflows]:
                 destination_workflows.append(workflow.copy(project=destination_project.id))
         return destination_workflows
@@ -505,7 +517,7 @@ class SevenBridgesPlatform(Platform):
         task_cost = 0.0
         try:
             task_cost = task.price.amount
-        except:
+        except Exception:
             pass
         return task_cost
 
@@ -579,7 +591,10 @@ class SevenBridgesPlatform(Platform):
         """
         if isinstance(platform_object, sevenbridges.File):
             if platform_object.is_folder():
-                if not isinstance(input_to_compare, dict) or input_to_compare.get("class") != "Directory":
+                if (
+                    not isinstance(input_to_compare, dict) or
+                    input_to_compare.get("class") != "Directory"
+                ):
                     self.logger.info("Platform object is a Directory, but input to compare is not")
                     return False
                 folder_contents = list(platform_object.list_files().all())
@@ -592,8 +607,10 @@ class SevenBridgesPlatform(Platform):
                     # Directory inputs are sorted alphabetically, so while this check is order-
                     # dependent, this is unlikely to differ in reality if elements are the same
                     if not self._compare_platform_object(platform_element, input_element):
-                        self.logger.info("Platform object and input to compare were not the same: %s != %s",
-                                         platform_element, input_element)
+                        self.logger.info(
+                            "Platform object and input to compare were not the same: %s != %s",
+                            platform_element, input_element
+                        )
                         return False
                 return True
             elif not isinstance(input_to_compare, dict) or input_to_compare.get("class") != "File":
@@ -611,8 +628,10 @@ class SevenBridgesPlatform(Platform):
             for task_input, input_element in zip(platform_object, input_to_compare):
                 # this is intentionally sensitive to order
                 if not self._compare_platform_object(task_input, input_element):
-                    self.logger.info("Platform object and input to compare were not the same: %s != %s",
-                                     task_input, input_element)
+                    self.logger.info(
+                        "Platform object and input to compare were not the same: %s != %s",
+                        task_input, input_element
+                    )
                     return False
             return True
         else:
@@ -643,8 +662,10 @@ class SevenBridgesPlatform(Platform):
                             self.logger.info("Input %s not found in task %s", input_name, task.id)
                             break
                         if not self._compare_platform_object(task.inputs[input_name], input_value):
-                            self.logger.info("Task %s input %s does not match: %s vs query %s",
-                                             task.id, input_name, task.inputs[input_name], input_value)
+                            self.logger.info(
+                                "Task %s input %s does not match: %s vs query %s",
+                                task.id, input_name, task.inputs[input_name], input_value
+                            )
                             break
                     else:
                         # If we didn't break, then the task matches the inputs
@@ -712,7 +733,8 @@ class SevenBridgesPlatform(Platform):
                         sbgfile = self.api.files.get(id=entry['location'])
                     set_file_metadata(sbgfile, entry['metadata'])
 
-        use_spot_instance = execution_settings.get('use_spot_instance', True) if execution_settings else True
+        use_spot_instance = execution_settings.get('use_spot_instance', True) \
+            if execution_settings else True
         sbg_execution_settings = {'use_elastic_disk': True, 'use_memoization': True}
 
         # This metadata code will come out as part of the metadata removal effort.
@@ -852,7 +874,10 @@ class SevenBridgesPlatform(Platform):
         for division in divisions:
             platform_users = self.api.users.query(division=division, limit=500).all()
             for platform_user in platform_users:
-                if user.lower() in platform_user.username.lower() or platform_user.email.lower() == user.lower():
+                if (
+                    user.lower() in platform_user.username.lower() or
+                    platform_user.email.lower() == user.lower()
+                ):
                     return platform_user
         return None
 

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -566,11 +566,24 @@ class SevenBridgesPlatform(Platform):
                 return task.outputs[output_name].name
         raise ValueError(f"Output {output_name} does not exist for task {task.name}.")
 
-    def get_tasks_by_name(self, project, task_name=None): # -> list(sevenbridges.Task):
+    def _compare_file_dict(self, file_obj, file_dict):
+        """
+        Compare a SevenBridges File object to a CWL object of class File
+        :param input_obj:  Object to attempt to simplify
+        :return: File object id, or the input object unchanged
+        """
+        if not isinstance(file_obj, sevenbridges.File):
+            raise ValueError(f"Object {file_obj} is not a file object")
+        if file_dict.get("class") != "File":
+            raise ValueError(f"Object {file_dict} is not of class File")
+        return file_dict.get("path") == file_obj.id
+
+    def get_tasks_by_name(self, project:str, task_name:str=None, inputs_to_compare:dict=None): # -> list(sevenbridges.Task):
         '''
         Get all processes/tasks in a project with a specified name
         :param project: The project to search
         :param task_name: The name of the process to search for (if None return all tasks)
+        :param inputs_to_compare: Inputs as well to ensure equivalency (eg for reuse)
         :return: List of tasks
         '''
         tasks = []

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -578,7 +578,17 @@ class SevenBridgesPlatform(Platform):
         :return: True if the object is equivalent, False otherwise
         """
         if isinstance(platform_object, sevenbridges.File):
-            if not isinstance(input_to_compare, dict) or input_to_compare.get("class") != "File":
+            if platform_object.is_folder():
+                if not isinstance(input_to_compare, dict) or input_to_compare.get("class") != "Directory":
+                    return False
+                for platform_element, input_element in zip(
+                    platform_element['input'].list_files().all(),
+                    input_to_compare['listing']):
+                    # this is intentionally sensitive to order
+                    if not _compare_platform_object(platform_file, input_element):
+                        return False
+                return True
+            elif not isinstance(input_to_compare, dict) or input_to_compare.get("class") != "File":
                 return False
             else:
                 return platform_object.id == input_to_compare.get("path")

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -590,7 +590,7 @@ class SevenBridgesPlatform(Platform):
                     folder_contents,
                     input_to_compare['listing']):
                     # this is intentionally sensitive to order
-                    if not _compare_platform_object(platform_element, input_element):
+                    if not self._compare_platform_object(platform_element, input_element):
                         self.logger.info("Platform object and input to compare were not the same: %s != %s",
                                          platform_element, input_element)
                         return False

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -614,7 +614,7 @@ class SevenBridgesPlatform(Platform):
                     self.logger.info("Platform object and input to compare were not the same: %s != %s",
                                      task_input, input_element)
                     return False
-                return True
+            return True
         else:
             return platform_object == input_to_compare
 

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -618,12 +618,17 @@ class SevenBridgesPlatform(Platform):
         else:
             return platform_object == input_to_compare
 
-    def get_tasks_by_name(self, project:str, task_name:str=None, inputs_to_compare:dict=None): # -> list(sevenbridges.Task):
+    def get_tasks_by_name(self,
+                          project:str,
+                          task_name:str=None,
+                          inputs_to_compare:dict=None): # -> list(sevenbridges.Task):
         '''
-        Get all processes/tasks in a project with a specified name
+        Get all processes/tasks in a project with a specified name, or all tasks
+        if no name is specified. Optionally, compare task inputs to ensure
+        equivalency (eg for reuse).
         :param project: The project to search
         :param task_name: The name of the process to search for (if None return all tasks)
-        :param inputs_to_compare: Inputs as well to ensure equivalency (eg for reuse)
+        :param inputs_to_compare: Inputs to compare to ensure task equivalency
         :return: List of tasks
         '''
         tasks = []

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -582,7 +582,7 @@ class SevenBridgesPlatform(Platform):
                 if not isinstance(input_to_compare, dict) or input_to_compare.get("class") != "Directory":
                     self.logger.info("Platform object is a Directory, but input to compare is not")
                     return False
-                folder_contents = list(platform_object['input'].list_files().all())
+                folder_contents = list(platform_object.list_files().all())
                 if not len(folder_contents) == len(input_to_compare['listing']):
                     self.logger.info("Platform object and input to compare are not the same length")
                     return False

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -640,15 +640,15 @@ class SevenBridgesPlatform(Platform):
                 if task.name == task_name:
                     for input_name, input_value in inputs_to_compare.items():
                         if input_name not in task.inputs:
-                            self.logger.info("Input %s not found in task %s", input_name, task.name)
+                            self.logger.info("Input %s not found in task %s", input_name, task.id)
                             break
                         if not self._compare_platform_object(task.inputs[input_name], input_value):
                             self.logger.info("Task %s input %s does not match: %s vs query %s",
-                                             task.name, input_name, task.inputs[input_name], input_value)
+                                             task.id, input_name, task.inputs[input_name], input_value)
                             break
                     else:
                         # If we didn't break, then the task matches the inputs
-                        self.logger.info("Task %s matches inputs", task.name)
+                        self.logger.info("Task %s matches inputs", task.id)
                         tasks.append(task)
         return tasks
 

--- a/tests/test_arvados_platform.py
+++ b/tests/test_arvados_platform.py
@@ -646,8 +646,8 @@ class TestArvadosPlaform(unittest.TestCase):
                 'e': [3, 4]  # Different key
             }
         }
-        # This should still return True because we only check if keys in input_to_compare are in task_input
-        self.assertTrue(self.platform._compare_inputs(nested1, {'a': 1}))
+        # This should now return False because we require dictionaries to have identical keys
+        self.assertFalse(self.platform._compare_inputs(nested1, {'a': 1}))
         
         # Test nested structure with Directory objects
         dir1 = {

--- a/tests/test_arvados_platform.py
+++ b/tests/test_arvados_platform.py
@@ -1,6 +1,7 @@
 '''
 Test Module for Arvados Platform
 '''
+# pylint: disable=protected-access
 import json
 import os
 
@@ -111,7 +112,9 @@ class TestArvadosPlaform(unittest.TestCase):
     def test_get_task_output(self, mock__load_cwl_output):
         ''' Test that get_task_output can handle cases when the cwl_output is {} '''
         # Set up test parameters
-        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"}, container={})
+        task = ArvadosTask(container_request={"uuid":"uuid",
+                                              "output_uuid": "output_uuid"},
+                           container={})
         # Set up supporting mocks
         mock__load_cwl_output.return_value = {}
         # Test
@@ -121,9 +124,13 @@ class TestArvadosPlaform(unittest.TestCase):
 
     @mock.patch('cwl_platform.arvados_platform.ArvadosPlatform._load_cwl_output')
     def test_get_task_output_optional_step_file_missing(self, mock__load_cwl_output):
-        ''' Test that get_task_output can handle cases when an optional step file is missing in cwl_output '''
+        ''' 
+        Test that get_task_output can handle cases when an optional 
+        step file is missing in cwl_output 
+        '''
         # Set up test parameters
-        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"}, container={})
+        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"},
+                           container={})
         # Set up supporting mocks
         mock__load_cwl_output.return_value = {'some_output_field': None}
         # Test
@@ -132,9 +139,13 @@ class TestArvadosPlaform(unittest.TestCase):
         self.assertIsNone(actual_value)
     @mock.patch('cwl_platform.arvados_platform.ArvadosPlatform._load_cwl_output')
     def test_get_task_output_nonexistent_output(self, mock__load_cwl_output):
-        ''' Test that get_task_output can handle cases when the output is non-existent in cwl_output '''
+        ''' 
+        Test that get_task_output can handle cases when the 
+        output is non-existent in cwl_output
+        '''
         # Set up test parameters
-        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"}, container={})
+        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"},
+                           container={})
         # Set up supporting mocks
         mock__load_cwl_output.return_value = {'other_output_field': None}
         # Test
@@ -147,10 +158,14 @@ class TestArvadosPlaform(unittest.TestCase):
         ''' Test get_task_output_filename method with single dictionary output '''
         # Set up mocks
         expected_filename = "output_file.txt"
-        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"}, container={})
-        mock_collection.return_value.open.return_value.__enter__.return_value.read.return_value = json.dumps({
-            "output_name": {"basename": expected_filename}
-        })
+        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"},
+                           container={})
+        mock_collection.return_value. \
+            open.return_value \
+            .__enter__.return_value \
+            .read.return_value = json.dumps({
+                "output_name": {"basename": expected_filename}
+            })
 
         # Test
         filename = self.platform.get_task_output_filename(task, "output_name")
@@ -165,9 +180,14 @@ class TestArvadosPlaform(unittest.TestCase):
         ''' Test get_task_output_filename method with list output '''
         # Set up mocks
         expected_filenames = ["output_file1.txt", "output_file2.txt"]
-        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"}, container={})
-        mock_collection.return_value.open.return_value.__enter__.return_value.read.return_value = json.dumps({
-            "output_name": [{"basename": expected_filenames[0]}, {"basename": expected_filenames[1]}]
+        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"},
+                           container={})
+        mock_collection.return_value \
+            .open.return_value \
+            .__enter__.return_value \
+            .read.return_value = json.dumps({
+            "output_name": [{"basename": expected_filenames[0]},
+                            {"basename": expected_filenames[1]}]
         })
 
         # Test
@@ -180,10 +200,14 @@ class TestArvadosPlaform(unittest.TestCase):
     def test_output_filename_nonexistant_output_name(self, mock_collection):
         ''' Test get_task_output_filename method when output name does not exist '''
         # Set up mocks
-        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"}, container={})
-        mock_collection.return_value.open.return_value.__enter__.return_value.read.return_value = json.dumps({
-            "output_name": []
-        })
+        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"},
+                           container={})
+        mock_collection.return_value \
+            .open.return_value \
+            .__enter__.return_value \
+            .read.return_value = json.dumps({
+                "output_name": []
+            })
 
         # Test
         with self.assertRaises(ValueError):
@@ -193,10 +217,15 @@ class TestArvadosPlaform(unittest.TestCase):
     def test_output_filename_none(self, mock_collection):
         ''' Test get_task_output_filename method when value of output_name is None '''
         # Set up mocks
-        task = ArvadosTask(container_request={"uuid":"uuid", "output_uuid": "output_uuid"}, container={})
-        mock_collection.return_value.open.return_value.__enter__.return_value.read.return_value = json.dumps({
-            "output_name": None
-        })
+        task = ArvadosTask(container_request={"uuid": "uuid",
+                                              "output_uuid": "output_uuid"},
+                           container={})
+        mock_collection.return_value \
+            .open.return_value \
+            .__enter__.return_value \
+            .read.return_value = json.dumps({
+                "output_name": None
+            })
 
         # Test
         with self.assertRaises(ValueError):
@@ -271,11 +300,13 @@ class TestArvadosPlaform(unittest.TestCase):
         with mock.patch('arvados.collection.Collection') as _:
             with mock.patch('arvados.collection.Collection') as mock_destination_collection_object:
                 # Test
-                result = self.platform.copy_folder(source_project, source_folder, destination_project)
+                result = self.platform.copy_folder(source_project,
+                                                   source_folder,
+                                                   destination_project)
 
                 # Assertions
-                self.assertIsNotNone(result)  # Ensure the result is not None
-                self.assertEqual(result['uuid'], 'destination-uuid')  # Ensure we got the correct destination UUID
+                self.assertIsNotNone(result)
+                self.assertEqual(result['uuid'], 'destination-uuid')
                 # Ensure a file is copied to the destination collection
                 self.assertEqual(mock_destination_collection_object().copy.call_count, 1)
                 self.assertEqual(mock_destination_collection_object().save.call_count, 1)
@@ -301,7 +332,9 @@ class TestArvadosPlaform(unittest.TestCase):
 
     @mock.patch("cwl_platform.arvados_platform.ArvadosPlatform._lookup_collection_from_foldername")
     @mock.patch("cwl_platform.arvados_platform.ArvadosPlatform._get_files_list_in_collection")
-    def test_copy_folder_create_destination_collection(self, mock_get_files_list, mock_lookup_folder_name):
+    def test_copy_folder_create_destination_collection(self,
+                                                       mock_get_files_list,
+                                                       mock_lookup_folder_name):
         ''' Test copy_folder method with file streaming to CREATE the destination collection'''
         # Set up test parameters
         source_project = {"uuid": "source-project-uuid"}
@@ -348,7 +381,9 @@ class TestArvadosPlaform(unittest.TestCase):
         with mock.patch('arvados.collection.Collection') as _:
             with mock.patch('arvados.collection.Collection') as mock_destination_collection_object:
                 # Test
-                result = self.platform.copy_folder(source_project, source_folder, destination_project)
+                result = self.platform.copy_folder(source_project,
+                                                   source_folder,
+                                                   destination_project)
 
                 # Assertions
                 self.assertIsNotNone(result)  # Ensure the result is not None
@@ -366,7 +401,9 @@ class TestArvadosPlaform(unittest.TestCase):
         project = {'uuid': 'aproject'}
         dest_folder = '/inputs'
         # Set up supporting mocks
-        self.platform.api.collections().create().execute.return_value = {'uuid': 'a_destination_collection'}
+        self.platform.api.collections().create().execute.return_value = {
+            'uuid': 'a_destination_collection'
+        }
         # Test
         actual_result = self.platform.upload_file(
             filename, project, dest_folder, destination_filename=None, overwrite=False)
@@ -394,14 +431,17 @@ class TestArvadosPlaform(unittest.TestCase):
 
         # Mock the API calls
         self.platform.api.container_requests().list.return_value = MagicMock()
-        mock_keyset_list_all = MagicMock(return_value=[mock_container_request1, mock_container_request2])
-        
+        mock_keyset_list_all = MagicMock(return_value = [mock_container_request1,
+                                                       mock_container_request2])
+
         with mock.patch('arvados.util.keyset_list_all', mock_keyset_list_all):
-            self.platform.api.containers().get().execute.side_effect = [mock_container1, mock_container2]
-            
+            self.platform.api.containers().get().execute.side_effect = [
+                mock_container1, mock_container2
+            ]
+
             # Test
             result = self.platform.get_tasks_by_name({'uuid': 'project_uuid'}, matching_task_name)
-            
+
             # Assert
             self.assertEqual(len(result), 1)
             self.assertEqual(result[0].container_request['name'], matching_task_name)
@@ -427,14 +467,17 @@ class TestArvadosPlaform(unittest.TestCase):
 
         # Mock the API calls
         self.platform.api.container_requests().list.return_value = MagicMock()
-        mock_keyset_list_all = MagicMock(return_value=[mock_container_request1, mock_container_request2])
-        
+        mock_keyset_list_all = MagicMock(return_value=[mock_container_request1,
+                                                       mock_container_request2])
+
         with mock.patch('arvados.util.keyset_list_all', mock_keyset_list_all):
-            self.platform.api.containers().get().execute.side_effect = [mock_container1, mock_container2]
-            
+            self.platform.api.containers().get().execute.side_effect = [
+                mock_container1, mock_container2
+            ]
+
             # Test
             result = self.platform.get_tasks_by_name({'uuid': 'project_uuid'})
-            
+
             # Assert
             self.assertEqual(len(result), 2)
             self.assertEqual(result[0].container_request['name'], task1_name)
@@ -443,7 +486,7 @@ class TestArvadosPlaform(unittest.TestCase):
     def test_get_tasks_by_name_match_name_and_inputs(self):
         ''' Test get_tasks_by_name method with task name and matching inputs '''
         task_name = "sample_task"
-        
+
         # Define inputs to compare
         inputs_to_compare = {
             'input1': {
@@ -461,7 +504,7 @@ class TestArvadosPlaform(unittest.TestCase):
                 }
             ]
         }
-        
+
         # Mock container requests with matching and non-matching inputs
         mock_container_request1 = {
             'name': task_name,
@@ -486,7 +529,7 @@ class TestArvadosPlaform(unittest.TestCase):
                 }
             }
         }
-        
+
         mock_container_request2 = {
             'name': task_name,
             'container_uuid': 'container2',
@@ -510,24 +553,28 @@ class TestArvadosPlaform(unittest.TestCase):
                 }
             }
         }
-        
+
         mock_container1 = {'uuid': 'container1'}
         mock_container2 = {'uuid': 'container2'}
-        
+
         # Mock the API calls
         self.platform.api.container_requests().list.return_value = MagicMock()
-        mock_keyset_list_all = MagicMock(return_value=[mock_container_request1, mock_container_request2])
-        
+        mock_keyset_list_all = MagicMock(return_value=[
+            mock_container_request1, mock_container_request2
+        ])
+
         with mock.patch('arvados.util.keyset_list_all', mock_keyset_list_all):
-            self.platform.api.containers().get().execute.side_effect = [mock_container1, mock_container2]
-            
+            self.platform.api.containers().get().execute.side_effect = [
+                mock_container1, mock_container2
+            ]
+
             # Test
             result = self.platform.get_tasks_by_name(
                 {'uuid': 'project_uuid'},
                 task_name=task_name,
                 inputs_to_compare=inputs_to_compare
             )
-            
+
             # Assert
             self.assertEqual(len(result), 1)
             self.assertEqual(result[0].container_request['uuid'], 'request1')
@@ -537,15 +584,15 @@ class TestArvadosPlaform(unittest.TestCase):
         # Test string values
         self.assertTrue(self.platform._compare_inputs("test", "test"))
         self.assertFalse(self.platform._compare_inputs("test", "different"))
-        
+
         # Test numeric values
         self.assertTrue(self.platform._compare_inputs(123, 123))
         self.assertFalse(self.platform._compare_inputs(123, 456))
-        
+
         # Test boolean values
         self.assertTrue(self.platform._compare_inputs(True, True))
         self.assertFalse(self.platform._compare_inputs(True, False))
-        
+
         # Test None values
         self.assertTrue(self.platform._compare_inputs(None, None))
         self.assertFalse(self.platform._compare_inputs(None, "not none"))
@@ -562,14 +609,14 @@ class TestArvadosPlaform(unittest.TestCase):
             'path': 'keep:file1'
         }
         self.assertTrue(self.platform._compare_inputs(file1, file1_compare))
-        
+
         # Test non-matching File objects
         file2 = {
             'class': 'File',
             'location': 'keep:file2'
         }
         self.assertFalse(self.platform._compare_inputs(file1, file2))
-        
+
         # Test File object with missing location
         file_missing_location = {
             'class': 'File'
@@ -582,15 +629,15 @@ class TestArvadosPlaform(unittest.TestCase):
         list1 = [1, 2, 3]
         list2 = [1, 2, 3]
         self.assertTrue(self.platform._compare_inputs(list1, list2))
-        
+
         # Test non-matching simple lists
         list3 = [1, 2, 4]
         self.assertFalse(self.platform._compare_inputs(list1, list3))
-        
+
         # Test lists of different lengths
         list4 = [1, 2]
         self.assertFalse(self.platform._compare_inputs(list1, list4))
-        
+
         # Test lists with File objects
         list_files1 = [
             {'class': 'File', 'location': 'keep:file1'},
@@ -601,7 +648,7 @@ class TestArvadosPlaform(unittest.TestCase):
             {'class': 'File', 'path': 'keep:file2'}
         ]
         self.assertTrue(self.platform._compare_inputs(list_files1, list_files2))
-        
+
         # Test lists with non-matching File objects
         list_files3 = [
             {'class': 'File', 'location': 'keep:file1'},
@@ -627,7 +674,7 @@ class TestArvadosPlaform(unittest.TestCase):
             }
         }
         self.assertTrue(self.platform._compare_inputs(nested1, nested2))
-        
+
         # Test nested dictionaries with different values
         nested3 = {
             'a': 1,
@@ -637,18 +684,10 @@ class TestArvadosPlaform(unittest.TestCase):
             }
         }
         self.assertFalse(self.platform._compare_inputs(nested1, nested3))
-        
-        # Test nested dictionaries with different keys
-        nested4 = {
-            'a': 1,
-            'b': {
-                'c': 2,
-                'e': [3, 4]  # Different key
-            }
-        }
+
         # This should now return False because we require dictionaries to have identical keys
         self.assertFalse(self.platform._compare_inputs(nested1, {'a': 1}))
-        
+
         # Test nested structure with Directory objects
         dir1 = {
             'class': 'Directory',
@@ -667,7 +706,7 @@ class TestArvadosPlaform(unittest.TestCase):
             ]
         }
         self.assertTrue(self.platform._compare_inputs(dir1, dir2))
-        
+
         # Test nested structure with non-matching Directory objects
         dir3 = {
             'class': 'Directory',

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -375,6 +375,89 @@ class TestSevenBridgesPlaform(unittest.TestCase):
 
         self.assertFalse(result)
 
+    def test__compare_platform_directory_different_inner_elements(self):
+        '''
+        Test that we can compare two Directories with identical contents
+        The only difference in inputs is that the second file inside the nested folder is different
+
+        Project root
+        |- file_in_root
+        |- folder
+            |- file_inside_folder
+            |- nested_folder
+                |- file1_inside_nested_folder
+                |- file2_inside_nested_folder [present in test_platform_input, differing file in test_cwl_input]
+        '''
+        file_in_root_id = 'file_in_root'
+        folder_id = 'folder'
+        file_inside_folder_id = 'file_inside_folder'
+        nested_folder_id = 'nested_folder'
+        file1_inside_nested_folder_id = 'file1_inside_nested_folder'
+        file2_inside_nested_folder_id = 'file2_inside_nested_folder'
+
+        mock_file_in_root = MagicMock(spec=sevenbridges.File, id = file_in_root_id)
+        mock_file_in_root.is_folder.return_value = False
+        mock_folder = MagicMock(spec=sevenbridges.File, id = folder_id)
+        mock_folder.is_folder.return_value = True
+        mock_file_inside_folder = MagicMock(spec=sevenbridges.File, id = file_inside_folder_id)
+        mock_file_inside_folder.is_folder.return_value = False
+        mock_nested_folder = MagicMock(spec=sevenbridges.File, id = nested_folder_id)
+        mock_nested_folder.is_folder.return_value = True
+        mock_file1_inside_nested_folder = MagicMock(spec=sevenbridges.File, id = file1_inside_nested_folder_id)
+        mock_file1_inside_nested_folder.is_folder.return_value = False
+        mock_file2_inside_nested_folder = MagicMock(spec=sevenbridges.File, id = file2_inside_nested_folder_id)
+        mock_file2_inside_nested_folder.is_folder.return_value = False
+
+        # nested folder mocks
+        nested_folder_all_mock = MagicMock()
+        nested_folder_all_mock.return_value = [mock_file1_inside_nested_folder, mock_file2_inside_nested_folder]
+        nested_list_files_mock = MagicMock()
+        nested_list_files_mock.all = nested_folder_all_mock
+        mock_nested_folder.list_files.return_value = nested_list_files_mock
+
+        # first level folder mocks
+        folder_all_mock = MagicMock()
+        folder_all_mock.return_value = [mock_file_inside_folder, mock_nested_folder]
+        folder_list_files_mock = MagicMock()
+        folder_list_files_mock.all = folder_all_mock
+        mock_folder.list_files.return_value = folder_list_files_mock
+
+        test_platform_input = [mock_file_in_root, mock_folder]
+        test_cwl_input = [
+            {
+                'class': 'File',
+                'path': file_in_root_id
+            },
+            {
+                'class': 'Directory',
+                'path': folder_id,
+                'listing': [
+                    {
+                        'class': 'File',
+                        'path': file_inside_folder_id
+                    },
+                    {
+                        'class': 'Directory',
+                        'path': nested_folder_id,
+                        'listing': [
+                            {
+                                'class': 'File',
+                                'path': file1_inside_nested_folder_id
+                            },
+                            {
+                                'class': 'File',
+                                'path': "different file id"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+
+        self.assertFalse(result)
+
     def test_delete_task(self):
         ''' Test delete_task method '''
         # Set up mocks

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -121,6 +121,40 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
         self.assertFalse(result)
 
+    def test__compare_platform_object_array(self):
+        '''
+        Test that we can compare two simple arrays
+        '''
+        test_value = ["thing1", "thing2"]
+        test_platform_input = test_value
+        test_cwl_input = test_value
+
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+
+        self.assertTrue(result)
+
+    def test__compare_platform_file_array(self):
+        '''
+        Test that we can compare two File arrays
+        '''
+
+        test_file_id1 = 'a1234'
+        test_file_id2 = 'b2345'
+        mock_file1 = MagicMock(spec=sevenbridges.File, id = test_file_id1)
+        mock_file2 = MagicMock(spec=sevenbridges.File, id = test_file_id2)
+        test_platform_input = [mock_file1, mock_file2]
+        test_cwl_input = [{
+            'class': 'File',
+            'path': test_file_id1
+        },
+            {
+            'class': 'File',
+            'path': test_file_id2
+        }]
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+
+        self.assertTrue(result)
+
     def test_delete_task(self):
         ''' Test delete_task method '''
         # Set up mocks

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -633,37 +633,41 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         query_input = {
             'input1':{
                 'class': 'File',
-                'path': 'file1.txt'
+                'path': 'file1'
             },
             'input2': [
                 {
                     'class': 'File',
-                    'path': 'file2.txt'
+                    'path': 'file2'
                 },
                 {
                     'class': 'File',
-                    'path': 'file3.txt'
+                    'path': 'file3'
                 }
             ]
         }
-        
+
         # 2 total task present, both match names but task2 has a different input
-        file1 = MagicMock(spec=sevenbridges.File, id='file1')
-        file2 = MagicMock(spec=sevenbridges.File, id='file2')
-        file3 = MagicMock(spec=sevenbridges.File, id='file3')
-        different_file3 = MagicMock(spec=sevenbridges.File, id='different_file3')
-        
+        file1 = MagicMock(spec=sevenbridges.File, id = 'file1')
+        file1.is_folder.return_value = False
+        file2 = MagicMock(spec=sevenbridges.File, id = 'file2')
+        file2.is_folder.return_value = False
+        file3 = MagicMock(spec=sevenbridges.File, id = 'file3')
+        file3.is_folder.return_value = False
+        different_file3 = MagicMock(spec=sevenbridges.File, id = 'different_file3')
+        different_file3.is_folder.return_value = False
+
         task1 = MagicMock(spec=sevenbridges.Task)
         task1.name = task_name
         task1.inputs = {
-            'input1': [file1],
+            'input1': file1,
             'input2': [file2, file3],
         }
 
         task2 = MagicMock(spec=sevenbridges.Task)
         task2.name = task_name
         task2.inputs = {
-            'input1': [file1],
+            'input1': file1,
             'input2': [file2, different_file3],
         }
 

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -38,6 +38,89 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         self.platform.connect()
         self.assertTrue(self.platform.connected)
 
+    def test__compare_platform_object_string(self):
+        '''
+        Test that we can compare two non-list, non File inputs: string edition
+        '''
+        test_value = "test_string"
+        test_platform_input = test_value
+        test_cwl_input = test_value
+
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+
+        self.assertTrue(result)
+
+    def test__compare_platform_object_int(self):
+        '''
+        Test that we can compare two non-list, non File inputs: int edition
+        '''
+        test_value = 123
+        test_platform_input = test_value
+        test_cwl_input = test_value
+
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+
+        self.assertTrue(result)
+
+    def test__compare_platform_object_simple_unequal(self):
+        '''
+        Test that we can compare two non-list, non File inputs: not equal, string vs int
+        '''
+        test_value = 123
+        test_platform_input = test_value
+        test_cwl_input = "123"
+
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+
+        self.assertFalse(result)
+
+    def test__compare_platform_object_File_equal(self):
+        '''
+        Test that we can compare two equivalent File-type objects
+        '''
+        test_file_id = 'a1234'
+        mock_file = MagicMock(spec=sevenbridges.File, id = test_file_id)
+        test_platform_input = mock_file
+
+        test_cwl_input = {
+            'class': 'File',
+            'path': test_file_id
+        }
+
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+        self.assertTrue(result)
+
+    def test__compare_platform_object_File_not_equal(self):
+        '''
+        Test that we can correctly return false when comparing differing File-type objects
+        '''
+        test_file_id = 'a1234'
+        mock_file = MagicMock(spec=sevenbridges.File, id = test_file_id)
+        test_platform_input = mock_file
+
+        test_cwl_input = {
+            'class': 'File',
+            'path': "not the same id"
+        }
+
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+        self.assertFalse(result)
+
+    def test__compare_platform_object_File_not_file(self):
+        '''
+        Test that we can correctly return false when comparing a File and a non-file dict
+        '''
+        test_file_id = 'a1234'
+        mock_file = MagicMock(spec=sevenbridges.File, id = test_file_id)
+        test_platform_input = mock_file
+
+        test_cwl_input = {
+            'class': 'NotAFile'
+        }
+
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+        self.assertFalse(result)
+
     def test_delete_task(self):
         ''' Test delete_task method '''
         # Set up mocks

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -1,6 +1,7 @@
 '''
 Test Module for SevenBridges Platform
 '''
+# pylint: disable=protected-access
 import unittest
 import os
 import logging
@@ -19,7 +20,6 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         self.platform = SevenBridgesPlatform('SevenBridges')
         self.platform.api = MagicMock()
 
-        self.maxDiff = None
         logging.basicConfig(level=logging.INFO)
 
         return super().setUp()
@@ -241,14 +241,18 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         mock_file_inside_folder.is_folder.return_value = False
         mock_nested_folder = MagicMock(spec=sevenbridges.File, id = nested_folder_id)
         mock_nested_folder.is_folder.return_value = True
-        mock_file1_inside_nested_folder = MagicMock(spec=sevenbridges.File, id = file1_inside_nested_folder_id)
+        mock_file1_inside_nested_folder = MagicMock(spec=sevenbridges.File,
+                                                    id = file1_inside_nested_folder_id)
         mock_file1_inside_nested_folder.is_folder.return_value = False
-        mock_file2_inside_nested_folder = MagicMock(spec=sevenbridges.File, id = file2_inside_nested_folder_id)
+        mock_file2_inside_nested_folder = MagicMock(spec=sevenbridges.File,
+                                                    id = file2_inside_nested_folder_id)
         mock_file2_inside_nested_folder.is_folder.return_value = False
 
         # nested folder mocks
         nested_folder_all_mock = MagicMock()
-        nested_folder_all_mock.return_value = [mock_file1_inside_nested_folder, mock_file2_inside_nested_folder]
+        nested_folder_all_mock.return_value = [
+            mock_file1_inside_nested_folder, mock_file2_inside_nested_folder
+        ]
         nested_list_files_mock = MagicMock()
         nested_list_files_mock.all = nested_folder_all_mock
         mock_nested_folder.list_files.return_value = nested_list_files_mock
@@ -307,7 +311,8 @@ class TestSevenBridgesPlaform(unittest.TestCase):
             |- file_inside_folder
             |- nested_folder
                 |- file1_inside_nested_folder
-                |- file2_inside_nested_folder [present in test_platform_input, missing in test_cwl_input]
+                |- file2_inside_nested_folder [present in test_platform_input,
+                                               but missing in test_cwl_input]
         '''
         file_in_root_id = 'file_in_root'
         folder_id = 'folder'
@@ -324,14 +329,18 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         mock_file_inside_folder.is_folder.return_value = False
         mock_nested_folder = MagicMock(spec=sevenbridges.File, id = nested_folder_id)
         mock_nested_folder.is_folder.return_value = True
-        mock_file1_inside_nested_folder = MagicMock(spec=sevenbridges.File, id = file1_inside_nested_folder_id)
+        mock_file1_inside_nested_folder = MagicMock(spec=sevenbridges.File,
+                                                    id = file1_inside_nested_folder_id)
         mock_file1_inside_nested_folder.is_folder.return_value = False
-        mock_file2_inside_nested_folder = MagicMock(spec=sevenbridges.File, id = file2_inside_nested_folder_id)
+        mock_file2_inside_nested_folder = MagicMock(spec=sevenbridges.File,
+                                                    id = file2_inside_nested_folder_id)
         mock_file2_inside_nested_folder.is_folder.return_value = False
 
         # nested folder mocks
         nested_folder_all_mock = MagicMock()
-        nested_folder_all_mock.return_value = [mock_file1_inside_nested_folder, mock_file2_inside_nested_folder]
+        nested_folder_all_mock.return_value = [
+            mock_file1_inside_nested_folder, mock_file2_inside_nested_folder
+        ]
         nested_list_files_mock = MagicMock()
         nested_list_files_mock.all = nested_folder_all_mock
         mock_nested_folder.list_files.return_value = nested_list_files_mock
@@ -386,7 +395,8 @@ class TestSevenBridgesPlaform(unittest.TestCase):
             |- file_inside_folder
             |- nested_folder
                 |- file1_inside_nested_folder
-                |- file2_inside_nested_folder [present in test_platform_input, differing file in test_cwl_input]
+                |- file2_inside_nested_folder [present in test_platform_input,
+                                               but differing file in test_cwl_input]
         '''
         file_in_root_id = 'file_in_root'
         folder_id = 'folder'
@@ -403,14 +413,17 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         mock_file_inside_folder.is_folder.return_value = False
         mock_nested_folder = MagicMock(spec=sevenbridges.File, id = nested_folder_id)
         mock_nested_folder.is_folder.return_value = True
-        mock_file1_inside_nested_folder = MagicMock(spec=sevenbridges.File, id = file1_inside_nested_folder_id)
+        mock_file1_inside_nested_folder = MagicMock(spec=sevenbridges.File,
+                                                    id = file1_inside_nested_folder_id)
         mock_file1_inside_nested_folder.is_folder.return_value = False
-        mock_file2_inside_nested_folder = MagicMock(spec=sevenbridges.File, id = file2_inside_nested_folder_id)
+        mock_file2_inside_nested_folder = MagicMock(spec=sevenbridges.File,
+                                                    id = file2_inside_nested_folder_id)
         mock_file2_inside_nested_folder.is_folder.return_value = False
 
         # nested folder mocks
         nested_folder_all_mock = MagicMock()
-        nested_folder_all_mock.return_value = [mock_file1_inside_nested_folder, mock_file2_inside_nested_folder]
+        nested_folder_all_mock.return_value = [mock_file1_inside_nested_folder,
+                                               mock_file2_inside_nested_folder]
         nested_list_files_mock = MagicMock()
         nested_list_files_mock.all = nested_folder_all_mock
         mock_nested_folder.list_files.return_value = nested_list_files_mock

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -167,7 +167,7 @@ class TestSevenBridgesPlaform(unittest.TestCase):
 
     def test__compare_platform_simple_array_differing_length(self):
         '''
-        Test that we can compare two arrays with simple objects
+        Test that we can compare two arrays with simple objects but unequal length
         '''
         test_value = ["thing1", "thing2"]
         test_platform_input = test_value
@@ -179,12 +179,35 @@ class TestSevenBridgesPlaform(unittest.TestCase):
 
     def test__compare_platform_simple_array_not_equal(self):
         '''
-        Test that we can compare two arrays with simple objects
+        Test that we can compare two arrays of simple objects with unequal values
         '''
         test_value = ["thing1", "thing2"]
         test_platform_input = test_value
-        test_cwl_input = [1,2]
+        test_cwl_input = ["thing1",2]
 
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+
+        self.assertFalse(result)
+
+    def test__compare_platform_file_array_not_equal(self):
+        '''
+        Test that we can compare two File arrays with unequal values
+        '''
+        test_file_id1 = 'a1234'
+        test_file_id2 = 'b2345'
+        mock_file1 = MagicMock(spec=sevenbridges.File, id = test_file_id1)
+        mock_file1.is_folder.return_value = False
+        mock_file2 = MagicMock(spec=sevenbridges.File, id = test_file_id2)
+        mock_file2.is_folder.return_value = False
+        test_platform_input = [mock_file1, mock_file2]
+        test_cwl_input = [{
+            'class': 'File',
+            'path': test_file_id1
+        },
+            {
+            'class': 'File',
+            'path': "not the same id"
+        }]
         result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
 
         self.assertFalse(result)

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -582,14 +582,15 @@ class TestSevenBridgesPlaform(unittest.TestCase):
 
     def get_tasks_by_name(self):
         ''' Test get_tasks_by_name method '''
+        project = "test_project"
         matching_task_name = "matching_task"
         non_matching_task_name = "non_matching_task"
-        project = "test_project"
 
         # 2 total task present, only the one with a matching name should be returned
         mock_all = MagicMock()
         mock_task_match = MagicMock(spec=sevenbridges.Task)
         mock_task_match.name = matching_task_name
+
         mock_task_not_matching = MagicMock(spec=sevenbridges.Task)
         mock_task_not_matching.name = non_matching_task_name
         mock_all.return_value = [mock_task_not_matching, mock_task_match]
@@ -604,6 +605,28 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         self.assertNotIn(mock_task_not_matching, tasks,
                         "Expected task with non-matching name to not be returned, but it was.")
         self.assertEqual(len(tasks), 1, "Expected only a single task to be returned")
+
+    def get_tasks_by_name_match_all(self):
+        ''' Test get_tasks_by_name method '''
+        project = "test_project"
+        task1_name = "task1"
+        task2_name = "task2"
+
+        # 2 total task present, no name provided so we should return all
+        mock_all = MagicMock()
+        mock_task1 = MagicMock(spec=sevenbridges.Task)
+        mock_task1.name = task1_name
+
+        mock_task2 = MagicMock(spec=sevenbridges.Task)
+        mock_task2.name = task2_name
+        mock_all.return_value = [mock_task1, mock_task2]
+
+        self.platform.api.tasks.query.return_value.all = mock_all
+
+        tasks = self.platform.get_tasks_by_name(matching_task_name, project)
+
+        self.platform.api.tasks.query.assert_called_once_with(name=matching_task_name, project=project)
+        self.assertEqual(tasks, [mock_task1, mock_task2])
 
     def test_get_task_input_non_file_obj(self):
         '''

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -580,6 +580,31 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         # Assert
         task.run.assert_called_once_with()
 
+    def get_tasks_by_name(self):
+        ''' Test get_tasks_by_name method '''
+        matching_task_name = "matching_task"
+        non_matching_task_name = "non_matching_task"
+        project = "test_project"
+
+        # 2 total task present, only the one with a matching name should be returned
+        mock_all = MagicMock()
+        mock_task_match = MagicMock(spec=sevenbridges.Task)
+        mock_task_match.name = matching_task_name
+        mock_task_not_matching = MagicMock(spec=sevenbridges.Task)
+        mock_task_not_matching.name = non_matching_task_name
+        mock_all.return_value = [mock_task_not_matching, mock_task_match]
+
+        self.platform.api.tasks.query.return_value.all = mock_all
+
+        tasks = self.platform.get_tasks_by_name(matching_task_name, project)
+
+        self.platform.api.tasks.query.assert_called_once_with(name=matching_task_name, project=project)
+        self.assertIn(mock_task_match, tasks,
+                      "Expected task with matching name to be returned, but it wasn't.")
+        self.assertNotIn(mock_task_not_matching, tasks,
+                        "Expected task with non-matching name to not be returned, but it was.")
+        self.assertEqual(len(tasks), 1, "Expected only a single task to be returned")
+
     def test_get_task_input_non_file_obj(self):
         '''
         Test get_task_input method where the input is not a File object (e.g. string)

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -165,6 +165,30 @@ class TestSevenBridgesPlaform(unittest.TestCase):
 
         self.assertTrue(result)
 
+    def test__compare_platform_simple_array_differing_length(self):
+        '''
+        Test that we can compare two arrays with simple objects
+        '''
+        test_value = ["thing1", "thing2"]
+        test_platform_input = test_value
+        test_cwl_input = ["thing1"]
+
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+
+        self.assertFalse(result)
+
+    def test__compare_platform_simple_array_not_equal(self):
+        '''
+        Test that we can compare two arrays with simple objects
+        '''
+        test_value = ["thing1", "thing2"]
+        test_platform_input = test_value
+        test_cwl_input = [1,2]
+
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+
+        self.assertFalse(result)
+
     def test_delete_task(self):
         ''' Test delete_task method '''
         # Set up mocks

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -580,9 +580,9 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         # Assert
         task.run.assert_called_once_with()
 
-    def get_tasks_by_name(self):
+    def test_get_tasks_by_name(self):
         ''' Test get_tasks_by_name method '''
-        project = "test_project"
+        project_name = "test_project"
         matching_task_name = "matching_task"
         non_matching_task_name = "non_matching_task"
 
@@ -597,18 +597,18 @@ class TestSevenBridgesPlaform(unittest.TestCase):
 
         self.platform.api.tasks.query.return_value.all = mock_all
 
-        tasks = self.platform.get_tasks_by_name(matching_task_name, project)
+        result = self.platform.get_tasks_by_name(project_name, matching_task_name)
 
-        self.platform.api.tasks.query.assert_called_once_with(name=matching_task_name, project=project)
-        self.assertIn(mock_task_match, tasks,
+        self.platform.api.tasks.query.assert_called_once()
+        self.assertIn(mock_task_match, result,
                       "Expected task with matching name to be returned, but it wasn't.")
-        self.assertNotIn(mock_task_not_matching, tasks,
+        self.assertNotIn(mock_task_not_matching, result,
                         "Expected task with non-matching name to not be returned, but it was.")
-        self.assertEqual(len(tasks), 1, "Expected only a single task to be returned")
+        self.assertEqual(len(result), 1, "Expected only a single task to be returned")
 
-    def get_tasks_by_name_match_all(self):
+    def test_get_tasks_by_name_match_all(self):
         ''' Test get_tasks_by_name method '''
-        project = "test_project"
+        project_name = "test_project"
         task1_name = "task1"
         task2_name = "task2"
 
@@ -623,10 +623,9 @@ class TestSevenBridgesPlaform(unittest.TestCase):
 
         self.platform.api.tasks.query.return_value.all = mock_all
 
-        tasks = self.platform.get_tasks_by_name(matching_task_name, project)
+        result = self.platform.get_tasks_by_name(project_name)
 
-        self.platform.api.tasks.query.assert_called_once_with(name=matching_task_name, project=project)
-        self.assertEqual(tasks, [mock_task1, mock_task2])
+        self.assertEqual(result, [mock_task1, mock_task2])
 
     def test_get_task_input_non_file_obj(self):
         '''

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -296,6 +296,85 @@ class TestSevenBridgesPlaform(unittest.TestCase):
 
         self.assertTrue(result)
 
+    def test__compare_platform_directory_unequal_length(self):
+        '''
+        Test that we can compare two Directories with identical contents
+        The only difference in inputs is a missing file2 in inside the nested folder
+
+        Project root
+        |- file_in_root
+        |- folder
+            |- file_inside_folder
+            |- nested_folder
+                |- file1_inside_nested_folder
+                |- file2_inside_nested_folder [present in test_platform_input, missing in test_cwl_input]
+        '''
+        file_in_root_id = 'file_in_root'
+        folder_id = 'folder'
+        file_inside_folder_id = 'file_inside_folder'
+        nested_folder_id = 'nested_folder'
+        file1_inside_nested_folder_id = 'file1_inside_nested_folder'
+        file2_inside_nested_folder_id = 'file2_inside_nested_folder'
+
+        mock_file_in_root = MagicMock(spec=sevenbridges.File, id = file_in_root_id)
+        mock_file_in_root.is_folder.return_value = False
+        mock_folder = MagicMock(spec=sevenbridges.File, id = folder_id)
+        mock_folder.is_folder.return_value = True
+        mock_file_inside_folder = MagicMock(spec=sevenbridges.File, id = file_inside_folder_id)
+        mock_file_inside_folder.is_folder.return_value = False
+        mock_nested_folder = MagicMock(spec=sevenbridges.File, id = nested_folder_id)
+        mock_nested_folder.is_folder.return_value = True
+        mock_file1_inside_nested_folder = MagicMock(spec=sevenbridges.File, id = file1_inside_nested_folder_id)
+        mock_file1_inside_nested_folder.is_folder.return_value = False
+        mock_file2_inside_nested_folder = MagicMock(spec=sevenbridges.File, id = file2_inside_nested_folder_id)
+        mock_file2_inside_nested_folder.is_folder.return_value = False
+
+        # nested folder mocks
+        nested_folder_all_mock = MagicMock()
+        nested_folder_all_mock.return_value = [mock_file1_inside_nested_folder, mock_file2_inside_nested_folder]
+        nested_list_files_mock = MagicMock()
+        nested_list_files_mock.all = nested_folder_all_mock
+        mock_nested_folder.list_files.return_value = nested_list_files_mock
+
+        # first level folder mocks
+        folder_all_mock = MagicMock()
+        folder_all_mock.return_value = [mock_file_inside_folder, mock_nested_folder]
+        folder_list_files_mock = MagicMock()
+        folder_list_files_mock.all = folder_all_mock
+        mock_folder.list_files.return_value = folder_list_files_mock
+
+        test_platform_input = [mock_file_in_root, mock_folder]
+        test_cwl_input = [
+            {
+                'class': 'File',
+                'path': file_in_root_id
+            },
+            {
+                'class': 'Directory',
+                'path': folder_id,
+                'listing': [
+                    {
+                        'class': 'File',
+                        'path': file_inside_folder_id
+                    },
+                    {
+                        'class': 'Directory',
+                        'path': nested_folder_id,
+                        'listing': [
+                            {
+                                'class': 'File',
+                                'path': file1_inside_nested_folder_id
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+
+        self.assertFalse(result)
+
     def test_delete_task(self):
         ''' Test delete_task method '''
         # Set up mocks

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -3,6 +3,7 @@ Test Module for SevenBridges Platform
 '''
 import unittest
 import os
+import logging
 import mock
 from mock import MagicMock
 import sevenbridges
@@ -17,6 +18,10 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         os.environ['SESSION_ID'] = 'dummy'
         self.platform = SevenBridgesPlatform('SevenBridges')
         self.platform.api = MagicMock()
+
+        self.maxDiff = None
+        logging.basicConfig(level=logging.INFO)
+
         return super().setUp()
 
     def test_add_user_to_project(self):
@@ -74,12 +79,13 @@ class TestSevenBridgesPlaform(unittest.TestCase):
 
         self.assertFalse(result)
 
-    def test__compare_platform_object_File_equal(self):
+    def test__compare_platform_object_file(self):
         '''
         Test that we can compare two equivalent File-type objects
         '''
         test_file_id = 'a1234'
         mock_file = MagicMock(spec=sevenbridges.File, id = test_file_id)
+        mock_file.is_folder.return_value = False
         test_platform_input = mock_file
 
         test_cwl_input = {
@@ -90,12 +96,13 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
         self.assertTrue(result)
 
-    def test__compare_platform_object_File_not_equal(self):
+    def test__compare_platform_object_file_not_equal(self):
         '''
         Test that we can correctly return false when comparing differing File-type objects
         '''
         test_file_id = 'a1234'
         mock_file = MagicMock(spec=sevenbridges.File, id = test_file_id)
+        mock_file.is_folder.return_value = False
         test_platform_input = mock_file
 
         test_cwl_input = {
@@ -106,12 +113,13 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
         self.assertFalse(result)
 
-    def test__compare_platform_object_File_not_file(self):
+    def test__compare_platform_object_file_not_file(self):
         '''
         Test that we can correctly return false when comparing a File and a non-file dict
         '''
         test_file_id = 'a1234'
         mock_file = MagicMock(spec=sevenbridges.File, id = test_file_id)
+        mock_file.is_folder.return_value = False
         test_platform_input = mock_file
 
         test_cwl_input = {
@@ -121,9 +129,9 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
         self.assertFalse(result)
 
-    def test__compare_platform_object_array(self):
+    def test__compare_platform_simple_array(self):
         '''
-        Test that we can compare two simple arrays
+        Test that we can compare two arrays with simple objects
         '''
         test_value = ["thing1", "thing2"]
         test_platform_input = test_value
@@ -141,7 +149,9 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         test_file_id1 = 'a1234'
         test_file_id2 = 'b2345'
         mock_file1 = MagicMock(spec=sevenbridges.File, id = test_file_id1)
+        mock_file1.is_folder.return_value = False
         mock_file2 = MagicMock(spec=sevenbridges.File, id = test_file_id2)
+        mock_file2.is_folder.return_value = False
         test_platform_input = [mock_file1, mock_file2]
         test_cwl_input = [{
             'class': 'File',

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -212,6 +212,90 @@ class TestSevenBridgesPlaform(unittest.TestCase):
 
         self.assertFalse(result)
 
+
+    def test__compare_platform_directory(self):
+        '''
+        Test that we can compare two Directories with identical contents
+        This is complex just to test multiple cases all in one go:
+
+        Project root
+        |- file_in_root
+        |- folder
+            |- file_inside_folder
+            |- nested_folder
+                |- file1_inside_nested_folder
+                |- file2_inside_nested_folder
+        '''
+        file_in_root_id = 'file_in_root'
+        folder_id = 'folder'
+        file_inside_folder_id = 'file_inside_folder'
+        nested_folder_id = 'nested_folder'
+        file1_inside_nested_folder_id = 'file1_inside_nested_folder'
+        file2_inside_nested_folder_id = 'file2_inside_nested_folder'
+
+        mock_file_in_root = MagicMock(spec=sevenbridges.File, id = file_in_root_id)
+        mock_file_in_root.is_folder.return_value = False
+        mock_folder = MagicMock(spec=sevenbridges.File, id = folder_id)
+        mock_folder.is_folder.return_value = True
+        mock_file_inside_folder = MagicMock(spec=sevenbridges.File, id = file_inside_folder_id)
+        mock_file_inside_folder.is_folder.return_value = False
+        mock_nested_folder = MagicMock(spec=sevenbridges.File, id = nested_folder_id)
+        mock_nested_folder.is_folder.return_value = True
+        mock_file1_inside_nested_folder = MagicMock(spec=sevenbridges.File, id = file1_inside_nested_folder_id)
+        mock_file1_inside_nested_folder.is_folder.return_value = False
+        mock_file2_inside_nested_folder = MagicMock(spec=sevenbridges.File, id = file2_inside_nested_folder_id)
+        mock_file2_inside_nested_folder.is_folder.return_value = False
+
+        # nested folder mocks
+        nested_folder_all_mock = MagicMock()
+        nested_folder_all_mock.return_value = [mock_file1_inside_nested_folder, mock_file2_inside_nested_folder]
+        nested_list_files_mock = MagicMock()
+        nested_list_files_mock.all = nested_folder_all_mock
+        mock_nested_folder.list_files.return_value = nested_list_files_mock
+
+        # first level folder mocks
+        folder_all_mock = MagicMock()
+        folder_all_mock.return_value = [mock_file_inside_folder, mock_nested_folder]
+        folder_list_files_mock = MagicMock()
+        folder_list_files_mock.all = folder_all_mock
+        mock_folder.list_files.return_value = folder_list_files_mock
+
+        test_platform_input = [mock_file_in_root, mock_folder]
+        test_cwl_input = [
+            {
+                'class': 'File',
+                'path': file_in_root_id
+            },
+            {
+                'class': 'Directory',
+                'path': folder_id,
+                'listing': [
+                    {
+                        'class': 'File',
+                        'path': file_inside_folder_id
+                    },
+                    {
+                        'class': 'Directory',
+                        'path': nested_folder_id,
+                        'listing': [
+                            {
+                                'class': 'File',
+                                'path': file1_inside_nested_folder_id
+                            },
+                            {
+                                'class': 'File',
+                                'path': file2_inside_nested_folder_id
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+
+        result = self.platform._compare_platform_object(test_platform_input, test_cwl_input)
+
+        self.assertTrue(result)
+
     def test_delete_task(self):
         ''' Test delete_task method '''
         # Set up mocks

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -298,7 +298,7 @@ class TestSevenBridgesPlaform(unittest.TestCase):
 
     def test__compare_platform_directory_unequal_length(self):
         '''
-        Test that we can compare two Directories with identical contents
+        Test that we can compare two Directories with differing number of files inside
         The only difference in inputs is a missing file2 in inside the nested folder
 
         Project root
@@ -377,7 +377,7 @@ class TestSevenBridgesPlaform(unittest.TestCase):
 
     def test__compare_platform_directory_different_inner_elements(self):
         '''
-        Test that we can compare two Directories with identical contents
+        Test that we can compare two Directories which have different inner files
         The only difference in inputs is that the second file inside the nested folder is different
 
         Project root


### PR DESCRIPTION
Add functionality to check previous tasks not just by name but also compare their inputs, which enables us to correctly avoid reusing tasks which have different input parameters.

Also upgraded to the newest version of Arvados, 3.1.1 which has a number of improvements over the last version, 2.7.4 which we had pinned.