### PR TITLE
Remove sbg endpoint with inference

### DIFF
--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -852,4 +852,3 @@ class SevenBridgesPlatform(Platform):
         if session_id:
             return True
         return False
-    

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -27,7 +27,7 @@ class SevenBridgesPlatform(Platform):
 
         if self._session_id:
             self.api_endpoint = self._get_api_endpoint()
-            self.token = None
+            self.token = "dummy"
         else:
             if os.path.exists(os.path.expanduser("~") + '/.sevenbridges/credentials') is True:
                 self.api_config = sevenbridges.Config(profile='default')
@@ -123,13 +123,13 @@ class SevenBridgesPlatform(Platform):
             return default_api_url
         except KeyError:
             self.logger.warning(
-                "Error: 'app' or 'id' key not found in job.json, defaulting to US API URL")
+                "'app' or 'id' key not found in job.json, defaulting to US API URL")
             return default_api_url
         except json.JSONDecodeError:
             print(
-                "Error: job.json is not a valid JSON file"
+                "job.json is not a valid JSON file, defaulting to US API URL"
             )
-            return None
+            return default_api_url
 
     def _list_all_files(self, files=None, project=None):
         """


### PR DESCRIPTION
if running on the platform, we still need to set api_endpoint and give a dummy value for token or else will get 
```
2025-05-19T18:12:48.630344083Z sevenbridges.errors.SbgError: URL is missing! Configuration may contain errors, or the url parameter is missing.
```
(see [task](https://igor.sbgenomics.com/u/bristol-myers-squibb/p-00000000-0001-rna-seq/tasks/4806f32f-8163-4703-8a92-ba9b9382501c/stats/) using [remove_sbg_endpoint](https://github.com/NGS360/PAML/tree/remove_sbg_endpoint) branch]

figuring out what our actual platform is is surprisingly challenging - it's not in any env var - but can be inferred from the app id in the jobs.json file in the CWD.

this PR adds a function to determine which endpoint should be used based on this value. will work for US (MTP + STP), EU, and China.

If for any reason we can not determine this, it defaults to the US MTP api, where we are migrating the vast majority of our runs.

tested with RNA-Seq launcher: https://igor.sbgenomics.com/u/bristol-myers-squibb/p-00000000-0001-rna-seq/tasks/d00bb766-72dd-4e3b-b8cd-cf0e19ef941c/