### PR TITLE
Fix ArvadosPlatform::get_tasks_by_name

### DIFF
--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -9,6 +9,7 @@ import pathlib
 import re
 import subprocess
 import tempfile
+from typing import List
 
 import chardet
 
@@ -728,7 +729,7 @@ class ArvadosPlatform(Platform):
                           project:str,
                           task_name:str=None,
                           inputs_to_compare:dict=None,
-                          tasks:list=None): # -> list(ArvadosTask):
+                          tasks:list=None) -> List['ArvadosTask']:
         '''
         Get all processes/tasks in a project with a specified name, or all tasks
         if no name is specified. Optionally, compare task inputs to ensure

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -749,11 +749,14 @@ class ArvadosPlatform(Platform):
             if task_name:
                 filters.append(["name", '=', task_name])
 
-            tasks = arvados.util.keyset_list_all(self.api.container_requests().list, filters=filters)
+            container_requests = arvados.util.keyset_list_all(self.api.container_requests().list, filters=filters)
+        else:
+            # Use provided tasks
+            container_requests = [task.container_request for task in tasks]
 
         matching_tasks = []
 
-        for container_request in tasks:
+        for container_request in container_requests:
             # Skip if name doesn't match (when task_name is specified)
             if task_name and container_request['name'] != task_name:
                 continue

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -729,7 +729,7 @@ class ArvadosPlatform(Platform):
                           project:str,
                           task_name:str=None,
                           inputs_to_compare:dict=None,
-                          tasks:list=None) -> List['ArvadosTask']:
+                          tasks:list=None) -> List[ArvadosTask]:
         '''
         Get all processes/tasks in a project with a specified name, or all tasks
         if no name is specified. Optionally, compare task inputs to ensure

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -729,7 +729,7 @@ class ArvadosPlatform(Platform):
                           project:str,
                           task_name:str=None,
                           inputs_to_compare:dict=None,
-                          tasks:list=None) -> List[ArvadosTask]:
+                          tasks:List[ArvadosTask]=None) -> List[ArvadosTask]:
         '''
         Get all processes/tasks in a project with a specified name, or all tasks
         if no name is specified. Optionally, compare task inputs to ensure


### PR DESCRIPTION
This PR does two things:
1. It fixes the missing return type to List[ArvadosTask] and parameters tasks to List[ArvadosTask] instead of generic lists, to be more informative.
2. Fixes issue when get a list of previously fetched tasks is not handled correctly.
