### PR TITLE
Add check for container_uuid

### DIFF
--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -764,25 +764,30 @@ class ArvadosPlatform(Platform):
                           inputs_to_compare: dict = None,
                           tasks: List[ArvadosTask] = None) -> List[ArvadosTask]:
         '''
-        Get all processes/tasks in a project with a specified name, or all tasks
-        if no name is specified. Optionally, compare task inputs to ensure
-        equivalency (eg for reuse).
+        Get all processes/tasks in a project with a specified name, or all
+        tasks if no name is specified. Optionally, compare task inputs to
+        ensure equivalency (eg for reuse).
         :param project: The project to search
-        :param task_name: The name of the process to search for (if None return all tasks)
+        :param task_name: The name of the process to search for
+            (if None return all tasks)
         :param inputs_to_compare: Inputs to compare to ensure task equivalency
-        :param tasks: List of tasks to search in (if None, query all tasks in project)
+        :param tasks: List of tasks to search in
+            (if None, query all tasks in project)
         :return: List of tasks
         '''
         # Fetch tasks if not provided
         if tasks is None:
             # Filter out cancelled jobs (priority=0)
-            filters = [['owner_uuid', '=', project['uuid']], ['priority', '>', 0]]
+            filters = [['owner_uuid', '=', project['uuid']],
+                       ['priority', '>', 0]]
 
             # Add name filter if specified
             if task_name:
                 filters.append(["name", '=', task_name])
 
-            container_requests = arvados.util.keyset_list_all(self.api.container_requests().list, filters=filters)
+            container_requests = arvados.util.keyset_list_all(
+                self.api.container_requests().list, filters=filters
+            )
         else:
             # Use provided tasks
             container_requests = [task.container_request for task in tasks]
@@ -801,7 +806,8 @@ class ArvadosPlatform(Platform):
 
             # Get the container
             container = self.api.containers().get(
-                uuid=container_request['container_uuid']).execute()
+                uuid=container_request['container_uuid']
+            ).execute()
             task = ArvadosTask(container_request, container)
 
             # If no input comparison needed, add task to results
@@ -812,12 +818,18 @@ class ArvadosPlatform(Platform):
             # Get task inputs from either properties or mounts
             task_inputs = self._get_task_inputs(container_request, container)
             if not task_inputs:
-                self.logger.debug("Task %s has no cwl_input property", container_request['uuid'])
+                self.logger.debug(
+                    "Task %s has no cwl_input property",
+                    container_request['uuid']
+                )
                 continue
 
             # Check if inputs match
-            if self._inputs_match(task_inputs, inputs_to_compare, container_request['uuid']):
-                self.logger.debug("Task %s matches inputs", container_request['uuid'])
+            if self._inputs_match(
+                task_inputs, inputs_to_compare, container_request['uuid']
+            ):
+                self.logger.debug(
+                    "Task %s matches inputs", container_request['uuid'])
                 matching_tasks.append(task)
 
         return matching_tasks

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -758,11 +758,13 @@ class ArvadosPlatform(Platform):
             f"Output {output_name} does not exist for task {task.container_request['uuid']}."
         )
 
-    def get_tasks_by_name(self,
-                          project,
-                          task_name: str = None,
-                          inputs_to_compare: dict = None,
-                          tasks: List[ArvadosTask] = None) -> List[ArvadosTask]:
+    def get_tasks_by_name(
+        self,
+        project,
+        task_name: str = None,
+        inputs_to_compare: dict = None,
+        tasks: List[ArvadosTask] = None
+    ) -> List[ArvadosTask]:
         '''
         Get all processes/tasks in a project with a specified name, or all
         tasks if no name is specified. Optionally, compare task inputs to

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -778,8 +778,10 @@ class ArvadosPlatform(Platform):
         # Fetch tasks if not provided
         if tasks is None:
             # Filter out cancelled jobs (priority=0)
-            filters = [['owner_uuid', '=', project['uuid']],
-                       ['priority', '>', 0]]
+            filters = [
+                ['owner_uuid', '=', project['uuid']],
+                ['priority', '>', 0]
+            ]
 
             # Add name filter if specified
             if task_name:

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -760,9 +760,9 @@ class ArvadosPlatform(Platform):
 
     def get_tasks_by_name(self,
                           project,
-                          task_name:str=None,
-                          inputs_to_compare:dict=None,
-                          tasks:List[ArvadosTask]=None) -> List[ArvadosTask]:
+                          task_name: str = None,
+                          inputs_to_compare: dict = None,
+                          tasks: List[ArvadosTask] = None) -> List[ArvadosTask]:
         '''
         Get all processes/tasks in a project with a specified name, or all tasks
         if no name is specified. Optionally, compare task inputs to ensure

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -761,6 +761,11 @@ class ArvadosPlatform(Platform):
             if task_name and container_request['name'] != task_name:
                 continue
 
+            # Skip is container_request does not have a container_uuid
+            # in the case a task was cancelled or never executed?
+            if container_request['container_uuid'] is None:
+                continue
+
             # Get the container
             container = self.api.containers().get(
                 uuid=container_request['container_uuid']).execute()

--- a/tests/test_arvados_platform.py
+++ b/tests/test_arvados_platform.py
@@ -333,9 +333,6 @@ class TestArvadosPlaform(unittest.TestCase):
         destination_project = {"uuid": "destination-project-uuid"}
 
         # Set up mocks
-        # Mocking an empty source collection
-        source_collection = None
-
         mock_lookup_folder_name.side_effect = [(None, None)]
 
         result = self.platform.copy_folder(source_project, source_folder, destination_project)

--- a/tests/test_arvados_platform.py
+++ b/tests/test_arvados_platform.py
@@ -742,6 +742,31 @@ class TestArvadosPlaform(unittest.TestCase):
         # Assert
         self.assertListEqual(result, [])
 
+    def test_get_tasks_by_name_container_request_missing_uuid(self):
+        ''' Test get_tasks_by_name method when a container_request is missing uuid '''
+        project = {'uuid': 'project_uuid'}
+
+        # Mock container requests and containers
+        mock_container_request1 = {
+            'name': 'task1',
+            'container_uuid': None
+        }
+        mock_tasks = [
+            ArvadosTask(
+                container_request=mock_container_request1,
+                container=None
+            )
+        ]
+        # Test
+        result = self.platform.get_tasks_by_name(
+            project=project,
+            task_name='task1',
+            inputs_to_compare=None,
+            tasks=mock_tasks)
+
+        # Assert
+        self.assertEqual(len(result), 0)
+
     def test_compare_inputs_simple_values(self):
         ''' Test the _compare_inputs helper method with simple values '''
         # Test string values


### PR DESCRIPTION
get_tasks_by_name fails on some tasks in a project that do not have a container associated with a container_request, mostly due to a task being cancelled before it gets executed or somehow otherwise fails.