### PR TITLE
Fix copy_folder failure on Arvados due to NotADirectoryError

### DIFF
--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -236,12 +236,17 @@ class ArvadosPlatform(Platform):
                                        source_collection=source_collection)
             else:
                 # if subfolders exist in destination collection
-                if all(destination_file.stream_name() and destination_file.name() for destination_file in destination_files):
-                    if source_path not in [f"{destination_file.stream_name()}/{destination_file.name()}"
-                        for destination_file in destination_files]:
-                        target_collection.copy(source_path,
-                                               target_path=source_path,
-                                               source_collection=source_collection)
+                if all(destination_file.stream_name() and destination_file.name()
+                       for destination_file in destination_files):
+                    if source_path not in [
+                        f"{destination_file.stream_name()}/{destination_file.name()}"
+                        for destination_file in destination_files
+                    ]:
+                        target_collection.copy(
+                            source_path,
+                            target_path=source_path,
+                            source_collection=source_collection
+                        )
                 # if no subfolders exist in destination collection
                 else:
                     if source_path not in [destination_file.name()

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -161,17 +161,22 @@ class ArvadosPlatform(Platform):
         Give a folder path, return the corresponding collection in the project.
         
         :param project: The arvados project
-        :param folder: The "file path" of the folder e.g. /rootfolder
-        :return: Collection object for folder
+        :param folder: The "file path" of the folder e.g. /rootfolder or /rootfolder/subfolder
+        :return: Tuple of (collection object, subfolder path) or (None, None) if not found
         '''
-        # 1. Get the source collection
-        # The first element of the source_folder path is the name of the collection.
+        # 1. Split the folder path into collection_name and subfolder
+        # Handle whether or not a leading slash is included
         if folder.startswith('/'):
-            collection_name = folder.split('/')[1]
-        else:
-            collection_name = folder.split('/')[0]
+            folder = folder.lstrip('/')
 
-        # Look up the collect
+        # Split into parts
+        folder_parts = folder.split('/')
+        collection_name = folder_parts[0]
+
+        # Everything after the collection name is the subfolder
+        subfolder = '/'.join(folder_parts[1:]) if len(folder_parts) > 1 else ''
+
+        # 2. Look up the collection
         search_result = self.api.collections().list(filters=[
             ["owner_uuid", "=", project["uuid"]],
             ["name", "=", collection_name]
@@ -179,11 +184,11 @@ class ArvadosPlatform(Platform):
         if len(search_result['items']) > 0:
             self.logger.debug("Found source collection %s in project %s",
                               collection_name, project["uuid"])
-            return search_result['items'][0]
+            return search_result['items'][0], subfolder
 
         self.logger.error("Source collection %s not found in project %s",
                           collection_name, project["uuid"])
-        return None
+        return None, None
 
     # File methods
     def copy_folder(self, source_project, source_folder, destination_project):
@@ -191,30 +196,35 @@ class ArvadosPlatform(Platform):
         Copy folder to destination project
 
         :param source_project: The source project
-        :param source_folder: The source folder
+        :param source_folder: The source folder 
         :param destination_project: The destination project
         :return: The destination folder or None if not found
         '''
         self.logger.debug("Copying folder %s from project %s to project %s",
                           source_folder, source_project["uuid"], destination_project["uuid"])
 
-        source_collection = self._lookup_collection_from_foldername(source_project, source_folder)
+        source_collection, subfolder = self._lookup_collection_from_foldername(source_project, source_folder)
         if not source_collection:
             return None
 
         # 2. Get the destination project collection
-        destination_collection = self._lookup_collection_from_foldername(
-            destination_project, source_folder)
+        destination_collection, _ = self._lookup_collection_from_foldername(destination_project, source_folder)
+        # If the destination collection does not exist, create it
         if not destination_collection:
             destination_collection = self.api.collections().create(body={
                 "owner_uuid": destination_project["uuid"],
                 "name": source_collection['name'],
                 "description": source_collection["description"],
-                "preserve_version":True}).execute()
+                "preserve_version": True}).execute()
 
         # Copy the files from the reference project to the destination project
         self.logger.debug("Get list of files in source collection, %s", source_collection["uuid"])
-        source_files = self._get_files_list_in_collection(source_collection["uuid"])
+        # The subfolder is now extracted from _lookup_collection_from_foldername
+        # subfolder can be:
+        # '' (empty - root of collection)
+        # 'GRCh38ERCC.ensembl91.star-2.6.0c-index-archive'
+        # 'GRCh38ERCC.ensembl91.star-2.6.0c-index-archive/athirdlevelfolder'
+        source_files = self._get_files_list_in_collection(source_collection["uuid"], subfolder)
         self.logger.debug("Getting list of files in destination collection, %s",
                           destination_collection["uuid"])
         destination_files = self._get_files_list_in_collection(destination_collection["uuid"])

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -196,7 +196,7 @@ class ArvadosPlatform(Platform):
         :return: The destination folder or None if not found
         '''
         self.logger.debug("Copying folder %s from project %s to project %s",
-                     source_folder, source_project["uuid"], destination_project["uuid"])
+                          source_folder, source_project["uuid"], destination_project["uuid"])
 
         source_collection = self._lookup_collection_from_foldername(source_project, source_folder)
         if not source_collection:
@@ -222,12 +222,12 @@ class ArvadosPlatform(Platform):
         source_collection = arvados.collection.Collection(source_collection["uuid"])
         target_collection = arvados.collection.Collection(destination_collection['uuid'])
 
+        destination_paths = [
+            f"{dest_file.stream_name()}/{dest_file.name()}"
+            for dest_file in destination_files
+        ]
         for source_file in source_files:
             source_path = f"{source_file.stream_name()}/{source_file.name()}"
-            destination_paths = [
-                f"{dest_file.stream_name()}/{dest_file.name()}"
-                for dest_file in destination_files
-            ]
             if source_path not in destination_paths:
                 # take out the leading slash if the reference file is in the collection root
                 source_path = source_path.lstrip('/')

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -223,8 +223,7 @@ class ArvadosPlatform(Platform):
         target_collection = arvados.collection.Collection(destination_collection['uuid'])
 
         for source_file in source_files:
-
-            # check if there is any parent folders (source_file.stream_name() may contain subfolders)
+            # check if there is any parent folder (source_file.stream_name() may contain subfolders)
             if source_file.stream_name() and source_file.name():
                 source_path = f"{source_file.stream_name()}/{source_file.name()}"
             else:
@@ -255,7 +254,6 @@ class ArvadosPlatform(Platform):
                                                target_path=source_path,
                                                source_collection=source_collection)
         target_collection.save()
-
         self.logger.debug("Done copying folder.")
         return destination_collection
 

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -223,7 +223,7 @@ class ArvadosPlatform(Platform):
         target_collection = arvados.collection.Collection(destination_collection['uuid'])
 
         for source_file in source_files:
-            source_path = f"{source_file.stream_name()}/{source_file.name()}"
+            source_path = f"{source_file.stream_name()}{source_file.name()}"
             if source_path not in [f"{destination_file.stream_name()}/{destination_file.name()}"
                                 for destination_file in destination_files]:
                 target_collection.copy(source_path,

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -223,12 +223,31 @@ class ArvadosPlatform(Platform):
         target_collection = arvados.collection.Collection(destination_collection['uuid'])
 
         for source_file in source_files:
-            source_path = f"{source_file.stream_name()}/{source_file.name()}"
-            if source_path not in [f"{destination_file.stream_name()}/{destination_file.name()}"
-                                for destination_file in destination_files]:
+            # check if there is any parent folders (source_file.stream_name() may contain subfolders)
+            if source_file.stream_name() and source_file.name():
+                source_path = f"{source_file.stream_name()}/{source_file.name()}"
+            else:
+                source_path = source_file.name()
+            # check if file already exists in destination collection
+            if len(destination_files) == 0:
                 target_collection.copy(source_path,
                                        target_path=source_path,
                                        source_collection=source_collection)
+            else:
+                # if subfolders exist in destination collection
+                if all(destination_file.stream_name() and destination_file.name() for destination_file in destination_files):
+                    if source_path not in [f"{destination_file.stream_name()}/{destination_file.name()}"
+                        for destination_file in destination_files]:
+                        target_collection.copy(source_path,
+                                               target_path=source_path,
+                                               source_collection=source_collection)
+                # if no subfolders exist in destination collection
+                else:
+                    if source_path not in [destination_file.name()
+                        for destination_file in destination_files]:
+                        target_collection.copy(source_path,
+                                               target_path=source_path,
+                                               source_collection=source_collection)
         target_collection.save()
 
         self.logger.debug("Done copying folder.")

--- a/tests/test_arvados_platform.py
+++ b/tests/test_arvados_platform.py
@@ -423,9 +423,17 @@ class TestArvadosPlaform(unittest.TestCase):
         }
         # Mock files
         class MockFile:
-            def __init__(self, stream, name): self._stream, self._name = stream, name
-            def stream_name(self): return self._stream
-            def name(self): return self._name
+            """Mock file object for testing."""
+            def __init__(self, stream, name):
+                """Initialize MockFile."""
+                self._stream = stream
+                self._name = name
+            def stream_name(self):
+                """Return stream name."""
+                return self._stream
+            def name(self):
+                """Return file name."""
+                return self._name
         mock_get_files_list.side_effect = [
             [MockFile("folderA", "file1.txt")],  # source files
             []  # destination files
@@ -455,9 +463,17 @@ class TestArvadosPlaform(unittest.TestCase):
         destination_collection = {"uuid": "dest-coll-uuid", "name": "folderA", "description": "desc"}
         mock_lookup_folder_name.side_effect = [source_collection, destination_collection]
         class MockFile:
-            def __init__(self, stream, name): self._stream, self._name = stream, name
-            def stream_name(self): return self._stream
-            def name(self): return self._name
+            """Mock file object for testing."""
+            def __init__(self, stream, name):
+                """Initialize MockFile."""
+                self._stream = stream
+                self._name = name
+            def stream_name(self):
+                """Return stream name."""
+                return self._stream
+            def name(self):
+                """Return file name."""
+                return self._name
         mock_get_files_list.side_effect = [
             [
                 MockFile("folderA", "file1.txt"),
@@ -496,9 +512,17 @@ class TestArvadosPlaform(unittest.TestCase):
         destination_collection = {"uuid": "dest-coll-uuid", "name": "folderA", "description": "desc"}
         mock_lookup_folder_name.side_effect = [source_collection, destination_collection]
         class MockFile:
-            def __init__(self, stream, name): self._stream, self._name = stream, name
-            def stream_name(self): return self._stream
-            def name(self): return self._name
+            """Mock file object for testing."""
+            def __init__(self, stream, name):
+                """Initialize MockFile."""
+                self._stream = stream
+                self._name = name
+            def stream_name(self):
+                """Return stream name."""
+                return self._stream
+            def name(self):
+                """Return file name."""
+                return self._name
         mock_get_files_list.side_effect = [
             [MockFile("folderA", "file1.txt"), MockFile("folderA/subfolder", "file2.txt")],  # source
             []  # destination

--- a/tests/test_arvados_platform.py
+++ b/tests/test_arvados_platform.py
@@ -11,6 +11,19 @@ from mock import MagicMock
 
 from cwl_platform.arvados_platform import ArvadosPlatform, ArvadosTask, StreamFileReader
 
+class MockFile:
+    """Mock file object for testing."""
+    def __init__(self, stream, name):
+        """Initialize MockFile."""
+        self._stream = stream
+        self._name = name
+    def stream_name(self):
+        """Return stream name."""
+        return self._stream
+    def name(self):
+        """Return file name."""
+        return self._name
+
 class TestArvadosPlaform(unittest.TestCase):
     '''
     Test Class for Arvados Platform
@@ -421,19 +434,6 @@ class TestArvadosPlaform(unittest.TestCase):
             "name": "folderA",
             "description": "desc"
         }
-        # Mock files
-        class MockFile:
-            """Mock file object for testing."""
-            def __init__(self, stream, name):
-                """Initialize MockFile."""
-                self._stream = stream
-                self._name = name
-            def stream_name(self):
-                """Return stream name."""
-                return self._stream
-            def name(self):
-                """Return file name."""
-                return self._name
         mock_get_files_list.side_effect = [
             [MockFile("folderA", "file1.txt")],  # source files
             []  # destination files
@@ -462,18 +462,6 @@ class TestArvadosPlaform(unittest.TestCase):
         source_collection = {"uuid": "source-coll-uuid", "name": "folderA", "description": "desc"}
         destination_collection = {"uuid": "dest-coll-uuid", "name": "folderA", "description": "desc"}
         mock_lookup_folder_name.side_effect = [source_collection, destination_collection]
-        class MockFile:
-            """Mock file object for testing."""
-            def __init__(self, stream, name):
-                """Initialize MockFile."""
-                self._stream = stream
-                self._name = name
-            def stream_name(self):
-                """Return stream name."""
-                return self._stream
-            def name(self):
-                """Return file name."""
-                return self._name
         mock_get_files_list.side_effect = [
             [
                 MockFile("folderA", "file1.txt"),
@@ -511,18 +499,6 @@ class TestArvadosPlaform(unittest.TestCase):
         source_collection = {"uuid": "source-coll-uuid", "name": "folderA", "description": "desc"}
         destination_collection = {"uuid": "dest-coll-uuid", "name": "folderA", "description": "desc"}
         mock_lookup_folder_name.side_effect = [source_collection, destination_collection]
-        class MockFile:
-            """Mock file object for testing."""
-            def __init__(self, stream, name):
-                """Initialize MockFile."""
-                self._stream = stream
-                self._name = name
-            def stream_name(self):
-                """Return stream name."""
-                return self._stream
-            def name(self):
-                """Return file name."""
-                return self._name
         mock_get_files_list.side_effect = [
             [MockFile("folderA", "file1.txt"), MockFile("folderA/subfolder", "file2.txt")],  # source
             []  # destination
@@ -535,18 +511,17 @@ class TestArvadosPlaform(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(mock_dest_coll.copy.call_count, 2)
         mock_dest_coll.save.assert_called_once()
-        filename = "file.txt"
-        project = {'uuid': 'aproject'}
-        dest_folder = '/inputs'
         # Set up supporting mocks
         self.platform.api.collections().create().execute.return_value = {
             'uuid': 'a_destination_collection'
         }
-        # Test
-        actual_result = self.platform.upload_file(
-            filename, project, dest_folder, destination_filename=None, overwrite=False)
-        # Check results
-        self.assertEqual(actual_result, "keep:a_destination_collection/file.txt")
+        # Test and check results in one step
+        self.assertEqual(
+            self.platform.upload_file(
+                "file.txt", {'uuid': 'aproject'}, '/inputs', destination_filename=None, overwrite=False
+            ),
+            "keep:a_destination_collection/file.txt"
+        )
 
     def test_get_tasks_by_name(self):
         ''' Test get_tasks_by_name method with task name only '''

--- a/tests/test_arvados_platform.py
+++ b/tests/test_arvados_platform.py
@@ -400,7 +400,12 @@ class TestArvadosPlaform(unittest.TestCase):
     @mock.patch("cwl_platform.arvados_platform.ArvadosPlatform._get_files_list_in_collection")
     @mock.patch("cwl_platform.arvados_platform.ArvadosPlatform._lookup_collection_from_foldername")
     @mock.patch("arvados.collection.Collection")
-    def test_copy_folder_destination_collection_does_not_exist(self, mock_collection_cls, mock_lookup_folder_name, mock_get_files_list):
+    def test_copy_folder_destination_collection_does_not_exist(
+        self,
+        mock_collection_cls,
+        mock_lookup_folder_name,
+        mock_get_files_list
+    ):
         """Test copy_folder when destination collection does not exist."""
         source_project = {"uuid": "source-uuid"}
         destination_project = {"uuid": "dest-uuid"}
@@ -411,7 +416,11 @@ class TestArvadosPlaform(unittest.TestCase):
         # Mock lookup: source found, destination not found
         mock_lookup_folder_name.side_effect = [source_collection, destination_collection]
         # Mock API create
-        self.platform.api.collections().create().execute.return_value = {"uuid": "dest-coll-uuid", "name": "folderA", "description": "desc"}
+        self.platform.api.collections().create().execute.return_value = {
+            "uuid": "dest-coll-uuid",
+            "name": "folderA",
+            "description": "desc"
+        }
         # Mock files
         class MockFile:
             def __init__(self, stream, name): self._stream, self._name = stream, name
@@ -432,7 +441,12 @@ class TestArvadosPlaform(unittest.TestCase):
     @mock.patch("cwl_platform.arvados_platform.ArvadosPlatform._get_files_list_in_collection")
     @mock.patch("cwl_platform.arvados_platform.ArvadosPlatform._lookup_collection_from_foldername")
     @mock.patch("arvados.collection.Collection")
-    def test_copy_folder_destination_not_up_to_date(self, mock_collection_cls, mock_lookup_folder_name, mock_get_files_list):
+    def test_copy_folder_destination_not_up_to_date(
+        self,
+        mock_collection_cls,
+        mock_lookup_folder_name,
+        mock_get_files_list
+    ):
         """Test copy_folder when destination collection exists but is missing files."""
         source_project = {"uuid": "source-uuid"}
         destination_project = {"uuid": "dest-uuid"}
@@ -445,8 +459,13 @@ class TestArvadosPlaform(unittest.TestCase):
             def stream_name(self): return self._stream
             def name(self): return self._name
         mock_get_files_list.side_effect = [
-            [MockFile("folderA", "file1.txt"), MockFile("folderA", "file2.txt")],  # source
-            [MockFile("folderA", "file1.txt")]  # destination (missing file2.txt)
+            [
+                MockFile("folderA", "file1.txt"),
+                MockFile("folderA", "file2.txt")
+            ],  # source
+            [
+                MockFile("folderA", "file1.txt")
+            ]  # destination (missing file2.txt)
         ]
         mock_source_coll = MagicMock()
         mock_dest_coll = MagicMock()
@@ -463,7 +482,12 @@ class TestArvadosPlaform(unittest.TestCase):
     @mock.patch("cwl_platform.arvados_platform.ArvadosPlatform._get_files_list_in_collection")
     @mock.patch("cwl_platform.arvados_platform.ArvadosPlatform._lookup_collection_from_foldername")
     @mock.patch("arvados.collection.Collection")
-    def test_copy_folder_source_with_subfolders(self, mock_collection_cls, mock_lookup_folder_name, mock_get_files_list):
+    def test_copy_folder_source_with_subfolders(
+        self,
+        mock_collection_cls,
+        mock_lookup_folder_name,
+        mock_get_files_list
+    ):
         """Test copy_folder when source collection contains subfolders."""
         source_project = {"uuid": "source-uuid"}
         destination_project = {"uuid": "dest-uuid"}

--- a/tests/test_arvados_platform.py
+++ b/tests/test_arvados_platform.py
@@ -284,7 +284,7 @@ class TestArvadosPlaform(unittest.TestCase):
         }
 
         mock_lookup_folder_name.side_effect = [
-            source_collection, destination_collection
+            (source_collection, ''), (destination_collection, '')
         ]
 
         # Mock the source files
@@ -336,7 +336,7 @@ class TestArvadosPlaform(unittest.TestCase):
         # Mocking an empty source collection
         source_collection = None
 
-        mock_lookup_folder_name.side_effect = [source_collection]
+        mock_lookup_folder_name.side_effect = [(None, None)]
 
         result = self.platform.copy_folder(source_project, source_folder, destination_project)
 
@@ -365,7 +365,7 @@ class TestArvadosPlaform(unittest.TestCase):
         destination_collection = None
 
         mock_lookup_folder_name.side_effect = [
-            source_collection, destination_collection
+            (source_collection, ''), (destination_collection, '')
         ]
 
         # Mock the source files
@@ -427,7 +427,7 @@ class TestArvadosPlaform(unittest.TestCase):
         destination_collection = None  # Simulate not found
 
         # Mock lookup: source found, destination not found
-        mock_lookup_folder_name.side_effect = [source_collection, destination_collection]
+        mock_lookup_folder_name.side_effect = [(source_collection, ''), (destination_collection, None)]
         # Mock API create
         self.platform.api.collections().create().execute.return_value = {
             "uuid": "dest-coll-uuid",
@@ -461,7 +461,7 @@ class TestArvadosPlaform(unittest.TestCase):
         source_folder = "folderA"
         source_collection = {"uuid": "source-coll-uuid", "name": "folderA", "description": "desc"}
         destination_collection = {"uuid": "dest-coll-uuid", "name": "folderA", "description": "desc"}
-        mock_lookup_folder_name.side_effect = [source_collection, destination_collection]
+        mock_lookup_folder_name.side_effect = [(source_collection, ''), (destination_collection, '')]
         mock_get_files_list.side_effect = [
             [
                 MockFile("folderA", "file1.txt"),
@@ -498,7 +498,7 @@ class TestArvadosPlaform(unittest.TestCase):
         source_folder = "folderA"
         source_collection = {"uuid": "source-coll-uuid", "name": "folderA", "description": "desc"}
         destination_collection = {"uuid": "dest-coll-uuid", "name": "folderA", "description": "desc"}
-        mock_lookup_folder_name.side_effect = [source_collection, destination_collection]
+        mock_lookup_folder_name.side_effect = [(source_collection, ''), (destination_collection, '')]
         mock_get_files_list.side_effect = [
             [MockFile("folderA", "file1.txt"), MockFile("folderA/subfolder", "file2.txt")],  # source
             []  # destination


### PR DESCRIPTION
When running the launcher with platform Arvados, the script fails in copy_folder with the following error:

NotADirectoryError: [Errno 20] Not a directory: ''


This happens because copy_folder attempts to copy a path that is not recognized as a directory by the Arvados SDK. The collection.find() call fails when given an invalid path.