### PR TITLE
Allow to set priority for task execution in Arvados.

### DIFF
--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -1008,12 +1008,17 @@ class ArvadosPlatform(Platform):
                 cmd_spot_instance = "--enable-preemptible"
             else:
                 cmd_spot_instance = "--disable-preemptible"
+            priority = execution_settings.get(
+                'priority', 500) if execution_settings else 500
+            if priority < 0 or priority > 1000:
+                priority=500
 
             cmd_str = ['arvados-cwl-runner', '--no-wait',
                     '--defer-download',
                     '--varying-url-params=AWSAccessKeyId,Signature,Expires',
                     '--prefer-cached-downloads',
                     '--debug',
+                    '--priority', str(priority),
                     cmd_spot_instance,
                     '--project-uuid', project['uuid'],
                     '--name', name,


### PR DESCRIPTION
User can provide the field priority with values ranging from 0 = no priority <-> 1000 (highest priority)
and set the execution priority on Arvados

The default value is 500