### PR TITLE
Add workflow to get_tasks_by_name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,7 @@ install: build
 	python3 -m pip install --upgrade dist/*.whl
 
 test:
-	PYTHONPATH=src coverage run --source=src -m pytest -v --log-cli-level=INFO
-	coverage report
-	coverage html
+	PYTHONPATH=src pytest --cov=src --cov-report=term --cov-report=html:htmlcov -v --log-cli-level=INFO
 
 lint:
 	pylint src tests scripts--max-line-length=120 --ignore-imports=y

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,5 @@ test:
 	coverage html
 
 lint:
-	find . -name "*.py" | xargs pylint --max-line-length=120 --ignore-imports=y
+	pylint src tests scripts--max-line-length=120 --ignore-imports=y
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 build
 
 pytest
+pytest-cov
 mock
-coverage
 
 pylint

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -203,12 +203,14 @@ class ArvadosPlatform(Platform):
         self.logger.debug("Copying folder %s from project %s to project %s",
                           source_folder, source_project["uuid"], destination_project["uuid"])
 
-        source_collection, subfolder = self._lookup_collection_from_foldername(source_project, source_folder)
+        source_collection, subfolder = self._lookup_collection_from_foldername(
+            source_project, source_folder)
         if not source_collection:
             return None
 
         # 2. Get the destination project collection
-        destination_collection, _ = self._lookup_collection_from_foldername(destination_project, source_folder)
+        destination_collection, _ = self._lookup_collection_from_foldername(
+            destination_project, source_folder)
         # If the destination collection does not exist, create it
         if not destination_collection:
             destination_collection = self.api.collections().create(body={
@@ -759,7 +761,7 @@ class ArvadosPlatform(Platform):
         )
 
     def get_tasks_by_name(self,
-                          project:str,
+                          project:dict,
                           task_name:str=None,
                           workflow:str=None,
                           inputs_to_compare:dict=None,

--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -728,6 +728,7 @@ class ArvadosPlatform(Platform):
     def get_tasks_by_name(self,
                           project:str,
                           task_name:str=None,
+                          workflow:str=None,
                           inputs_to_compare:dict=None,
                           tasks:List[ArvadosTask]=None) -> List[ArvadosTask]:
         '''

--- a/src/cwl_platform/base_platform.py
+++ b/src/cwl_platform/base_platform.py
@@ -174,7 +174,9 @@ class Platform(ABC):
         '''
 
     @abstractmethod
-    def get_tasks_by_name(self, project:str, task_name:str=None, inputs_to_compare:dict=None, tasks:list=None):
+    def get_tasks_by_name(
+        self, project:str, task_name:str=None, workflow:str=None, inputs_to_compare:dict=None, tasks:list=None
+    ):
         '''
         Get all processes/tasks in a project with a specified name, or all tasks
         if no name is specified. Optionally, compare task inputs to ensure

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -1,8 +1,8 @@
 """
 NGS360 / GA4GH WES Platform class
 
-This module implements the Platform abstract base class using the GA4GH Workflow Execution Service (WES) API.
-The WES API provides a standard way to submit and manage workflows across different workflow execution systems.
+This module implements the Platform abstract base class using the GA4GH
+Workflow Execution Service (WES) API.
 """
 
 import os
@@ -46,6 +46,7 @@ class WESTask:
             outputs=task_dict.get("outputs"),
             inputs=task_dict.get("inputs"),
         )
+
 
 class NGS360Project():
     """
@@ -95,7 +96,8 @@ class NGS360Platform(Platform):
             - api_endpoint: WES API endpoint URL
             - auth_token: Authentication token for the WES API
         """
-        self.api_endpoint = kwargs.get("api_endpoint", os.environ.get("WES_API_ENDPOINT"))
+        self.api_endpoint = kwargs.get(
+            "api_endpoint", os.environ.get("WES_API_ENDPOINT"))
         if not self.api_endpoint:
             raise ValueError("WES API endpoint URL is required")
 
@@ -115,8 +117,6 @@ class NGS360Platform(Platform):
                 "Connected to WES API: %s",
                 response.get('workflow_type_versions', {})
             )
-            self.connected = True
-            # return True
         except requests.RequestException as e:
             self.logger.error("Failed to connect to WES API: %s", e)
             self.connected = False
@@ -126,7 +126,8 @@ class NGS360Platform(Platform):
             self.connected = False
             return False
 
-        self.ngs360_endpoint = kwargs.get("ngs360_endpoint", os.environ.get("NGS360_API_ENDPOINT"))
+        self.ngs360_endpoint = kwargs.get(
+            "ngs360_endpoint", os.environ.get("NGS360_API_ENDPOINT"))
         if not self.ngs360_endpoint:
             raise ValueError("NGS360 API endpoint URL is required")
         try:
@@ -136,6 +137,7 @@ class NGS360Platform(Platform):
             )
             response.raise_for_status()
             self.logger.info("Connected to NGS360 API")
+            self.connected = True
             return True
         except requests.RequestException as e:
             self.logger.error("Failed to connect to NGS360 API: %s", e)

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -571,16 +571,6 @@ class NGS360Platform(Platform):
 
         workflow_engine_parameters = {}
 
-        # output_bucket = os.environ.get("OMICS_OUTPUT_URI")
-        # if not output_bucket:
-        #     self.logger.error("Environmental variable OMICS_OUTPUT_URI is required.")
-        #    return None
-        # if not output_bucket.endswith('/'):
-        #     output_bucket = output_bucket + '/'
-        # output_uri = output_bucket + 'Project/' + project['project_id']+'/'
-        # workflow_engine_parameters = {
-        #     "outputUri": output_uri,
-        # }
         if execution_settings and "cacheId" in execution_settings:
             workflow_engine_parameters["cacheId"] = execution_settings["cacheId"]
         if execution_settings and "workflowVersionName" in execution_settings:
@@ -619,6 +609,9 @@ class NGS360Platform(Platform):
                 workflow_engine_parameters
             ),
         }
+        # AWS Omics can't handle inputs greater than 50,000 bytes.
+        with open(f"{project['project_id']}-{name}.parameters.json", mode="w") as f:
+            json.dump(parameters, f, indent=4)
         try:
             response = self._make_request("POST", "runs", data=data, files=files)
             run_id = response.get("run_id")

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -498,7 +498,7 @@ class NGS360Platform(Platform):
 
         return output.split('/')[-1]
 
-    def get_tasks_by_name(self, project, task_name=None, workflow=None,inputs_to_compare=None, tasks=None):
+    def get_tasks_by_name(self, project, task_name=None, workflow=None, inputs_to_compare=None, tasks=None):
         """
         Get all processes/tasks in a project with a specified name
 

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -496,7 +496,7 @@ class NGS360Platform(Platform):
 
         return output.split('/')[-1]
 
-    def get_tasks_by_name(self, project, task_name=None, inputs_to_compare=None, tasks=None):
+    def get_tasks_by_name(self, project, task_name=None, workflow=None, inputs_to_compare=None, tasks=None):
         """
         Get all processes/tasks in a project with a specified name
 
@@ -511,6 +511,8 @@ class NGS360Platform(Platform):
             params = {
                 "tags": json.dumps(tags)
             }
+            if workflow:
+                params["workflow"] = workflow
             response = self._make_request("GET", "runs", params=params)
             tasks = []
 
@@ -605,6 +607,8 @@ class NGS360Platform(Platform):
                 workflow_engine_parameters
             ),
         }
+        with open("parameters.json", "w") as f:
+            json.dump(parameters, f, indent=4)
         try:
             response = self._make_request("POST", "runs", data=data, files=files)
             run_id = response.get("run_id")

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -498,7 +498,7 @@ class NGS360Platform(Platform):
 
         return output.split('/')[-1]
 
-    def get_tasks_by_name(self, project, task_name=None, inputs_to_compare=None, tasks=None):
+    def get_tasks_by_name(self, project, task_name=None, workflow=None,inputs_to_compare=None, tasks=None):
         """
         Get all processes/tasks in a project with a specified name
 
@@ -510,8 +510,11 @@ class NGS360Platform(Platform):
             tags = {"ProjectId": project["project_id"]}
             if task_name:
                 tags["TaskName"] = task_name
+            filters = {"tags": tags}
+            if workflow:
+                filters["workflow_url"] = workflow
             params = {
-                "tags": json.dumps(tags)
+                "filters": json.dumps(filters)
             }
             response = self._make_request("GET", "runs", params=params)
             tasks = []

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -507,17 +507,24 @@ class NGS360Platform(Platform):
         :return: List of tasks
         """
         try:
-            tags = {"ProjectId": project["project_id"]}
-            if task_name:
-                tags["TaskName"] = task_name
-            filters = {"tags": tags}
-            if workflow:
-                filters["workflow_url"] = workflow
+            # The ** syntax in Python is called dictionary unpacking. 
+            # It lets you take the key/value pairs from one dictionary and “spread” them into another.
+            tags = {
+                "ProjectId": project["project_id"],
+                **({"TaskName": task_name} if task_name else {}),
+            }
+
+            filters = {
+                "tags": tags,
+                **({"workflow_url": workflow} if workflow else {}),
+            }
+
             params = {
                 "filters": json.dumps(filters)
             }
+
             response = self._make_request("GET", "runs", params=params)
-            tasks = []
+            matching_tasks = []
 
             for run in response.get("runs", []):
                 task = WESTask(
@@ -525,9 +532,9 @@ class NGS360Platform(Platform):
                     name=run.get("name", ""),
                     state=self.STATE_MAP.get(run.get("state", "UNKNOWN"), "Unknown"),
                 )
-                tasks.append(task)
+                matching_tasks.append(task)
 
-            return tasks
+            return matching_tasks
         except requests.RequestException as e:
             self.logger.error("Failed to get tasks: %s", e)
             return []

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -658,6 +658,7 @@ class SevenBridgesPlatform(Platform):
     def get_tasks_by_name(self,
                           project:str,
                           task_name:str=None,
+                          workflow:str=None,
                           inputs_to_compare:dict=None,
                           tasks:list=None) -> list: # -> list(sevenbridges.Task)
         '''

--- a/tests/test_ngs360_ga4gh_platform.py
+++ b/tests/test_ngs360_ga4gh_platform.py
@@ -455,8 +455,7 @@ class TestNGS360Platform(unittest.TestCase):
         '''
         Test export_file method (not supported in WES)
         '''
-        result = self.platform.export_file('file_id', 'bucket', 'prefix')
-        self.assertIsNone(result)
+        self.assertIsNone(self.platform.export_file('file_id', 'bucket', 'prefix'))
 
     @patch('requests.request')
     def test_connect_username_password_auth(self, mock_request):
@@ -595,12 +594,10 @@ class TestNGS360Platform(unittest.TestCase):
         self.assertEqual(result, 'test/folder')
 
         # Test rename_file
-        result = self.platform.rename_file('file_id', 'new_name.txt')
-        self.assertIsNone(result)
+        self.assertIsNone(self.platform.rename_file('file_id', 'new_name.txt'))
 
         # Test roll_file
-        result = self.platform.roll_file(project, 'file_name.txt')
-        self.assertIsNone(result)
+        self.assertIsNone(self.platform.roll_file(project, 'file_name.txt'))
 
     def test_task_methods_edge_cases(self):
         '''
@@ -664,12 +661,10 @@ class TestNGS360Platform(unittest.TestCase):
         project = {'project_id': 'test_project'}
 
         # Test add_user_to_project
-        result = self.platform.add_user_to_project('user_id', project, 'READ')
-        self.assertIsNone(result)
+        self.assertIsNone(self.platform.add_user_to_project('user_id', project, 'READ'))
 
         # Test get_user
-        result = self.platform.get_user('user_id')
-        self.assertIsNone(result)
+        self.assertIsNone(self.platform.get_user('user_id'))
 
     def test_cost_methods(self):
         '''
@@ -679,12 +674,10 @@ class TestNGS360Platform(unittest.TestCase):
         task = WESTask('test_run_id', 'Test Task')
 
         # Test get_project_cost
-        result = self.platform.get_project_cost(project)
-        self.assertIsNone(result)
+        self.assertIsNone(self.platform.get_project_cost(project))
 
         # Test get_task_cost
-        result = self.platform.get_task_cost(task)
-        self.assertIsNone(result)
+        self.assertIsNone(self.platform.get_task_cost(task))
 
     def test_current_task_and_users(self):
         '''
@@ -693,8 +686,7 @@ class TestNGS360Platform(unittest.TestCase):
         project = {'project_id': 'test_project'}
 
         # Test get_current_task
-        result = self.platform.get_current_task()
-        self.assertIsNone(result)
+        self.assertIsNone(self.platform.get_current_task())
 
         # Test get_project_users
         result = self.platform.get_project_users(project)

--- a/tests/test_ngs360_ga4gh_platform.py
+++ b/tests/test_ngs360_ga4gh_platform.py
@@ -288,7 +288,7 @@ class TestNGS360Platform(unittest.TestCase):
             headers={'Authorization': 'Bearer test_token'},
             data=None,
             files=None,
-            params={'tags': '{"ProjectId": "test_project"}'},
+            params={"filters": '{"tags": {"ProjectId": "test_project"}}'},
             timeout=120,
             auth=None
         )


### PR DESCRIPTION
This PR adds the ability to filter for workflows when calling get_tasks_by_name.  This is needed when multiple workflows are run in the same project with the same sample names.  Currently, this is only supported in Omics.  Support for SBG and Arvados needs to be added.

This PR also saves the parameters.json to disk when calling submit_task.