### PR TITLE
Check inputs when submitting tasks and improve error logging

### DIFF
--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -499,7 +499,9 @@ class NGS360Platform(Platform):
 
         return output.split('/')[-1]
 
-    def get_tasks_by_name(self, project, task_name=None, workflow=None, inputs_to_compare=None, tasks=None):
+    def get_tasks_by_name(
+        self, project, task_name=None, workflow=None, inputs_to_compare=None, tasks=None
+    ):
         """
         Get all processes/tasks in a project with a specified name
 
@@ -508,7 +510,7 @@ class NGS360Platform(Platform):
         :return: List of tasks
         """
         try:
-            # The ** syntax in Python is called dictionary unpacking. 
+            # The ** syntax in Python is called dictionary unpacking.
             # It lets you take the key/value pairs from one dictionary and “spread” them into another.
             tags = {
                 "ProjectId": project["project_id"],
@@ -541,8 +543,8 @@ class NGS360Platform(Platform):
                     if inputs_to_compare == run_details.get("request",{}).get("workflow_params",{}):
                         matching_tasks_inputs.append(task)
                 return matching_tasks_inputs
-            else:
-                return matching_tasks
+
+            return matching_tasks
 
         except requests.RequestException as e:
             self.logger.error("Failed to get tasks: %s", e)
@@ -577,17 +579,6 @@ class NGS360Platform(Platform):
             return None
 
         workflow_engine_parameters = {}
-
-        # output_bucket = os.environ.get("OMICS_OUTPUT_URI")
-        # if not output_bucket:
-        #     self.logger.error("Environmental variable OMICS_OUTPUT_URI is required.")
-        #    return None
-        # if not output_bucket.endswith('/'):
-        #     output_bucket = output_bucket + '/'
-        # output_uri = output_bucket + 'Project/' + project['project_id']+'/'
-        # workflow_engine_parameters = {
-        #     "outputUri": output_uri,
-        # }
         if execution_settings and "cacheId" in execution_settings:
             workflow_engine_parameters["cacheId"] = execution_settings["cacheId"]
         if execution_settings and "workflowVersionName" in execution_settings:

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -317,7 +317,6 @@ class NGS360Platform(Platform):
             dest_folder = dest_folder[1:]
 
         with open(filename, "rb") as f:
-            logging.info(f)
             response = requests.post(
                 f"{self.ngs360_endpoint}/api/v1/files/upload",
                 data={
@@ -640,7 +639,11 @@ class NGS360Platform(Platform):
 
             return task
         except requests.RequestException as e:
-            self.logger.error("Failed to submit task: %s", e)
+            try:
+                error_details = e.response.json().get('msg')
+            except:
+                error_details = str(e)
+            self.logger.error("Failed to submit task: %s", error_details)
             return None
         except (ValueError, KeyError, IOError) as e:
             self.logger.error("Failed to prepare or parse task submission: %s", e)

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -527,7 +527,6 @@ class NGS360Platform(Platform):
 
             response = self._make_request("GET", "runs", params=params)
             matching_tasks = []
-
             for run in response.get("runs", []):
                 task = WESTask(
                     run_id=run.get("run_id"),
@@ -536,7 +535,16 @@ class NGS360Platform(Platform):
                 )
                 matching_tasks.append(task)
 
-            return matching_tasks
+            if inputs_to_compare:
+                matching_tasks_inputs=[]
+                for task in matching_tasks:
+                    run_details = self._make_request("GET", f"runs/{task.run_id}")
+                    if inputs_to_compare == run_details.get("request",{}).get("workflow_params",{}):
+                        matching_tasks_inputs.append(task)
+                return matching_tasks_inputs
+            else:
+                return matching_tasks
+
         except requests.RequestException as e:
             self.logger.error("Failed to get tasks: %s", e)
             return []

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -584,6 +584,8 @@ class NGS360Platform(Platform):
             workflow_engine_parameters["cacheId"] = execution_settings["cacheId"]
         if execution_settings and "workflowVersionName" in execution_settings:
             workflow_engine_parameters["workflowVersionName"] = execution_settings["workflowVersionName"]
+        if execution_settings and "storageType" in execution_settings:
+            workflow_engine_parameters["storageType"] = execution_settings["storageType"]
 
         # Prepare the request data
         workflow_url = workflow

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -586,6 +586,8 @@ class NGS360Platform(Platform):
             workflow_engine_parameters["workflowVersionName"] = execution_settings["workflowVersionName"]
         if execution_settings and "storageType" in execution_settings:
             workflow_engine_parameters["storageType"] = execution_settings["storageType"]
+        if execution_settings and "storageCapacity" in execution_settings:
+            workflow_engine_parameters["storageCapacity"] = execution_settings["storageCapacity"]
 
         # Prepare the request data
         workflow_url = workflow


### PR DESCRIPTION
This PR includes changes to:
1. Use inputs_to_compare to check inputs of previous tasks in get_tasks_by_name().
2. Display actual detailed error message from GA4GH task submission when available.