### PR TITLE
Handle missing output files when list of files is returned in Arvados…

### DIFF
--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -717,7 +717,7 @@ class ArvadosPlatform(Platform):
             # If the output is a list, return a list of file locations
             output_files = []
             for output in output_field:
-                if 'location' in output:
+                if output and 'location' in output:
                     output_file = output['location']
                     output_files.append(
                         f"keep:{task.container_request['output_uuid']}/{output_file}"


### PR DESCRIPTION
When output ports of a pipeline are lists the current version of the function is looking for the key 'location' and returns it.
If a file is null (e.g. one of the list elements is missing) it crashes. 
The update ignores null elements of the list.

