### PR TITLE
Add intermediate ttl output to arvados-cwl-runner

### DIFF
--- a/src/cwl_platform/arvados_platform.py
+++ b/src/cwl_platform/arvados_platform.py
@@ -1020,6 +1020,7 @@ class ArvadosPlatform(Platform):
                     '--prefer-cached-downloads',
                     '--debug',
                     '--priority', str(priority),
+                    '--intermediate-output-ttl', '172800',
                     cmd_spot_instance,
                     '--project-uuid', project['uuid'],
                     '--name', name,


### PR DESCRIPTION
Implement intermediate-output-ttl