### PR TITLE
Rename api_endpoint variable to ga4gh_api_endpoint

### DIFF
--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -81,9 +81,13 @@ class NGS360Platform(Platform):
         """
         super().__init__(name)
         self.logger = logging.getLogger(__name__)
+
         self.ga4gh_api_endpoint = None
-        self.ngs360_endpoint = None
         self._ga4gh_auth_config = {}
+
+        self.ngs360_endpoint = None
+        self._ngs360_auth_config = {}
+
         self.projects = {}  # Map project names to project objects
         self.workflows = {}  # Map workflow names to workflow objects
         self.files = {}  # Map file paths to file objects
@@ -121,11 +125,9 @@ class NGS360Platform(Platform):
             )
         except requests.RequestException as e:
             self.logger.error("Failed to connect to WES API: %s", e)
-            self.connected = False
             return False
         except (ValueError, KeyError) as e:
             self.logger.error("Invalid response from WES API: %s", e)
-            self.connected = False
             return False
 
         # Get the endpoint from the kwargs or environment variable
@@ -135,19 +137,22 @@ class NGS360Platform(Platform):
             raise ValueError("NGS360 API endpoint URL is required")
 
         # Set up auth token for auth
+        auth_token = kwargs.get("ngs360_auth_token", os.environ.get("NGS360_AUTH_TOKEN"))
+        if auth_token:
+            self._ngs360_auth_config['token'] = auth_token
 
+        # Test connection by getting current user info
         try:
             response = requests.get(
-                f"{self.ngs360_endpoint}/",
+                f"{self.ngs360_endpoint}/auth/me",
+                headers={"Authorization": f"Bearer {self._ngs360_auth_config['token']}"} if 'token' in self._ngs360_auth_config else None,
                 timeout=30
             )
             response.raise_for_status()
             self.logger.info("Connected to NGS360 API")
-            self.connected = True
             return True
         except requests.RequestException as e:
             self.logger.error("Failed to connect to NGS360 API: %s", e)
-            self.connected = False
             return False
 
     def _make_request(self, method, path, **kwargs):

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -100,6 +100,8 @@ class NGS360Platform(Platform):
             - api_endpoint: WES API endpoint URL
             - auth_token: Authentication token for the WES API
         """
+        self.connected = False
+
         # Get the endpoint from the kwargs or environment variable
         self.ga4gh_api_endpoint = kwargs.get(
             "api_endpoint", os.environ.get("WES_API_ENDPOINT"))
@@ -150,10 +152,11 @@ class NGS360Platform(Platform):
             )
             response.raise_for_status()
             self.logger.info("Connected to NGS360 API")
-            return True
+            self.connected = True
         except requests.RequestException as e:
             self.logger.error("Failed to connect to NGS360 API: %s", e)
-            return False
+
+        return self.connected
 
     def _make_request(self, method, path, **kwargs):
         """

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -144,7 +144,7 @@ class NGS360Platform(Platform):
         # Test connection by getting current user info
         try:
             response = requests.get(
-                f"{self.ngs360_endpoint}/auth/me",
+                f"{self.ngs360_endpoint}/api/v1/auth/me",
                 headers={"Authorization": f"Bearer {self._ngs360_auth_config['token']}"} if 'token' in self._ngs360_auth_config else None,
                 timeout=30
             )

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -83,7 +83,7 @@ class NGS360Platform(Platform):
         self.logger = logging.getLogger(__name__)
         self.ga4gh_api_endpoint = None
         self.ngs360_endpoint = None
-        self._auth_config = {}
+        self._ga4gh_auth_config = {}
         self.projects = {}  # Map project names to project objects
         self.workflows = {}  # Map workflow names to workflow objects
         self.files = {}  # Map file paths to file objects
@@ -96,6 +96,7 @@ class NGS360Platform(Platform):
             - api_endpoint: WES API endpoint URL
             - auth_token: Authentication token for the WES API
         """
+        # Get the endpoint from the kwargs or environment variable
         self.ga4gh_api_endpoint = kwargs.get(
             "api_endpoint", os.environ.get("WES_API_ENDPOINT"))
         if not self.ga4gh_api_endpoint:
@@ -104,12 +105,12 @@ class NGS360Platform(Platform):
         # Set up auth token or username/password as auth
         auth_token = kwargs.get("auth_token", os.environ.get("WES_AUTH_TOKEN"))
         if auth_token:
-            self._auth_config['token'] = auth_token
+            self._ga4gh_auth_config['token'] = auth_token
         else:
             username = os.environ.get("WES_USERNAME")
             password = os.environ.get("WES_PASSWORD")
             if username and password:
-                self._auth_config['credentials'] = (username, password)
+                self._ga4gh_auth_config['credentials'] = (username, password)
 
         # Test connection by getting service info
         try:
@@ -127,10 +128,14 @@ class NGS360Platform(Platform):
             self.connected = False
             return False
 
+        # Get the endpoint from the kwargs or environment variable
         self.ngs360_endpoint = kwargs.get(
             "ngs360_endpoint", os.environ.get("NGS360_API_ENDPOINT"))
         if not self.ngs360_endpoint:
             raise ValueError("NGS360 API endpoint URL is required")
+
+        # Set up auth token for auth
+
         try:
             response = requests.get(
                 f"{self.ngs360_endpoint}/",
@@ -169,10 +174,10 @@ class NGS360Platform(Platform):
         headers = {}
         auth = None
 
-        if 'token' in self._auth_config:
-            headers["Authorization"] = f"Bearer {self._auth_config['token']}"
-        elif 'credentials' in self._auth_config:
-            auth = self._auth_config['credentials']
+        if 'token' in self._ga4gh_auth_config:
+            headers["Authorization"] = f"Bearer {self._ga4gh_auth_config['token']}"
+        elif 'credentials' in self._ga4gh_auth_config:
+            auth = self._ga4gh_auth_config['credentials']
 
         response = requests.request(
             method=method,

--- a/src/cwl_platform/ngs360_platform.py
+++ b/src/cwl_platform/ngs360_platform.py
@@ -81,12 +81,12 @@ class NGS360Platform(Platform):
         """
         super().__init__(name)
         self.logger = logging.getLogger(__name__)
-        self.api_endpoint = None
+        self.ga4gh_api_endpoint = None
+        self.ngs360_endpoint = None
         self._auth_config = {}
         self.projects = {}  # Map project names to project objects
         self.workflows = {}  # Map workflow names to workflow objects
         self.files = {}  # Map file paths to file objects
-        self.ngs360_endpoint = None
 
     def connect(self, **kwargs):
         """
@@ -96,9 +96,9 @@ class NGS360Platform(Platform):
             - api_endpoint: WES API endpoint URL
             - auth_token: Authentication token for the WES API
         """
-        self.api_endpoint = kwargs.get(
+        self.ga4gh_api_endpoint = kwargs.get(
             "api_endpoint", os.environ.get("WES_API_ENDPOINT"))
-        if not self.api_endpoint:
+        if not self.ga4gh_api_endpoint:
             raise ValueError("WES API endpoint URL is required")
 
         # Set up auth token or username/password as auth
@@ -161,7 +161,7 @@ class NGS360Platform(Platform):
             path = path[1:]
 
         # Make sure the API endpoint ends with a slash for proper joining
-        endpoint = self.api_endpoint
+        endpoint = self.ga4gh_api_endpoint
         if not endpoint.endswith("/"):
             endpoint = endpoint + "/"
 

--- a/tests/test_ngs360_ga4gh_platform.py
+++ b/tests/test_ngs360_ga4gh_platform.py
@@ -1,13 +1,13 @@
 '''
 Test WES Platform implementation
 '''
-# pylint: disable=protected-access
 import json
 import unittest
 from unittest.mock import patch, MagicMock
 import requests
 
 from cwl_platform.ngs360_platform import NGS360Platform, WESTask
+
 
 class TestNGS360Platform(unittest.TestCase):
     '''
@@ -18,9 +18,13 @@ class TestNGS360Platform(unittest.TestCase):
         Set up test environment
         '''
         self.platform = NGS360Platform('WES')
-        self.platform.api_endpoint = 'https://wes.example.com/ga4gh/wes/v1'
+
+        self.platform.ga4gh_api_endpoint = 'https://wes.example.com/ga4gh/wes/v1'
+        self.platform._ga4gh_auth_config = {'token': 'test_token'}
+
         self.platform.ngs360_endpoint = 'https://ngs360.example.com'
-        self.platform._ga4gh_auth_config['token'] = 'test_token'
+        self.platform._ngs360_auth_config = {'token': 'test_token'}
+
         self.platform.connected = True
 
     @patch('requests.request')

--- a/tests/test_ngs360_ga4gh_platform.py
+++ b/tests/test_ngs360_ga4gh_platform.py
@@ -91,11 +91,6 @@ class TestNGS360Platform(unittest.TestCase):
         '''
         Test connect method with username/password authentication
         '''
-        # Mock WES API response
-        #mock_response = MagicMock()
-        #mock_response.json.return_value = {'workflow_type_versions': {'CWL': {'workflow_type_version': ['v1.0']}}}
-        #mock_request.return_value = mock_response
-
         with patch('requests.get') as mock_get:
             # Mock NGS360 API response
             mock_ngs360_response = MagicMock()

--- a/tests/test_ngs360_ga4gh_platform.py
+++ b/tests/test_ngs360_ga4gh_platform.py
@@ -20,10 +20,10 @@ class TestNGS360Platform(unittest.TestCase):
         self.platform = NGS360Platform('WES')
 
         self.platform.ga4gh_api_endpoint = 'https://wes.example.com/ga4gh/wes/v1'
-        self.platform._ga4gh_auth_config = {'token': 'test_token'}
+        self.platform._ga4gh_auth_config = {'token': 'test_token'} # pylint: disable=protected-access
 
         self.platform.ngs360_endpoint = 'https://ngs360.example.com'
-        self.platform._ngs360_auth_config = {'token': 'test_token'}
+        self.platform._ngs360_auth_config = {'token': 'test_token'} # pylint: disable=protected-access
 
         self.platform.connected = True
 
@@ -112,7 +112,7 @@ class TestNGS360Platform(unittest.TestCase):
                 )
 
                 self.assertTrue(result)
-                self.assertEqual(platform._ga4gh_auth_config['credentials'], ('testuser', 'testpass'))
+                self.assertEqual(platform._ga4gh_auth_config['credentials'], ('testuser', 'testpass')) # pylint: disable=protected-access
 
                 # Verify the credentials are actually used as auth on the WES request
                 _, kwargs = mock_request.call_args

--- a/tests/test_ngs360_ga4gh_platform.py
+++ b/tests/test_ngs360_ga4gh_platform.py
@@ -91,14 +91,20 @@ class TestNGS360Platform(unittest.TestCase):
         '''
         Test connect method with username/password authentication
         '''
+        # Mock WES API response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'workflow_type_versions': {'CWL': {'workflow_type_version': ['v1.0']}}}
+        mock_request.return_value = mock_response
+
+        # Mock NGS360 API response
         with patch('requests.get') as mock_get:
-            # Mock NGS360 API response
             mock_ngs360_response = MagicMock()
             mock_ngs360_response.status_code = 200
             mock_get.return_value = mock_ngs360_response
 
-            # Test connect with username/password
-            with patch.dict('os.environ', {'WES_USERNAME': 'testuser', 'WES_PASSWORD': 'testpass'}):
+            # Test connect with username/password (clear env so a stray
+            # WES_AUTH_TOKEN doesn't preempt the username/password branch)
+            with patch.dict('os.environ', {'WES_USERNAME': 'testuser', 'WES_PASSWORD': 'testpass'}, clear=True):
                 platform = NGS360Platform('WES')
                 result = platform.connect(
                     api_endpoint='https://wes.example.com/ga4gh/wes/v1',
@@ -107,6 +113,11 @@ class TestNGS360Platform(unittest.TestCase):
 
                 self.assertTrue(result)
                 self.assertEqual(platform._ga4gh_auth_config['credentials'], ('testuser', 'testpass'))
+
+                # Verify the credentials are actually used as auth on the WES request
+                _, kwargs = mock_request.call_args
+                self.assertEqual(kwargs['auth'], ('testuser', 'testpass'))
+                self.assertNotIn('Authorization', kwargs['headers'])
 
     @patch('requests.request')
     def test_connect_wes_failure(self, mock_request):

--- a/tests/test_ngs360_ga4gh_platform.py
+++ b/tests/test_ngs360_ga4gh_platform.py
@@ -92,12 +92,12 @@ class TestNGS360Platform(unittest.TestCase):
         Test connect method with username/password authentication
         '''
         # Mock WES API response
-        mock_response = MagicMock()
-        mock_response.json.return_value = {'workflow_type_versions': {'CWL': {'workflow_type_version': ['v1.0']}}}
-        mock_request.return_value = mock_response
+        #mock_response = MagicMock()
+        #mock_response.json.return_value = {'workflow_type_versions': {'CWL': {'workflow_type_version': ['v1.0']}}}
+        #mock_request.return_value = mock_response
 
-        # Mock NGS360 API response
         with patch('requests.get') as mock_get:
+            # Mock NGS360 API response
             mock_ngs360_response = MagicMock()
             mock_ngs360_response.status_code = 200
             mock_get.return_value = mock_ngs360_response

--- a/tests/test_ngs360_ga4gh_platform.py
+++ b/tests/test_ngs360_ga4gh_platform.py
@@ -20,7 +20,7 @@ class TestNGS360Platform(unittest.TestCase):
         self.platform = NGS360Platform('WES')
         self.platform.api_endpoint = 'https://wes.example.com/ga4gh/wes/v1'
         self.platform.ngs360_endpoint = 'https://ngs360.example.com'
-        self.platform._auth_config['token'] = 'test_token'
+        self.platform._ga4gh_auth_config['token'] = 'test_token'
         self.platform.connected = True
 
     @patch('requests.request')
@@ -81,10 +81,73 @@ class TestNGS360Platform(unittest.TestCase):
             ngs360_endpoint='https://ngs360.example.com'
         )
         self.assertTrue(result)
-        self.assertTrue(platform.connected)
-        self.assertEqual(platform.api_endpoint, 'https://wes.example.com/ga4gh/wes/v1')
-        self.assertEqual(platform.ngs360_endpoint, 'https://ngs360.example.com')
-        self.assertEqual(platform._auth_config['token'], 'test_token')
+
+    @patch('requests.request')
+    def test_connect_username_password_auth(self, mock_request):
+        '''
+        Test connect method with username/password authentication
+        '''
+        # Mock WES API response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'workflow_type_versions': {'CWL': {'workflow_type_version': ['v1.0']}}}
+        mock_request.return_value = mock_response
+
+        # Mock NGS360 API response
+        with patch('requests.get') as mock_get:
+            mock_ngs360_response = MagicMock()
+            mock_ngs360_response.status_code = 200
+            mock_get.return_value = mock_ngs360_response
+
+            # Test connect with username/password
+            with patch.dict('os.environ', {'WES_USERNAME': 'testuser', 'WES_PASSWORD': 'testpass'}):
+                platform = NGS360Platform('WES')
+                result = platform.connect(
+                    api_endpoint='https://wes.example.com/ga4gh/wes/v1',
+                    ngs360_endpoint='https://ngs360.example.com'
+                )
+
+                self.assertTrue(result)
+                self.assertEqual(platform._ga4gh_auth_config['credentials'], ('testuser', 'testpass'))
+
+    @patch('requests.request')
+    def test_connect_wes_failure(self, mock_request):
+        '''
+        Test connect method with WES API failure
+        '''
+        # Mock failed WES API response
+        mock_request.side_effect = requests.RequestException("Connection failed")
+
+        # Test connect failure
+        platform = NGS360Platform('WES')
+        result = platform.connect(
+            api_endpoint='https://wes.example.com/ga4gh/wes/v1',
+            ngs360_endpoint='https://ngs360.example.com'
+        )
+
+        self.assertFalse(result)
+
+    @patch('requests.get')
+    @patch('requests.request')
+    def test_connect_ngs360_failure(self, mock_request, mock_get):
+        '''
+        Test connect method with NGS360 API failure
+        '''
+        # Mock successful WES API response
+        mock_wes_response = MagicMock()
+        mock_wes_response.json.return_value = {'workflow_type_versions': {'CWL': {'workflow_type_version': ['v1.0']}}}
+        mock_request.return_value = mock_wes_response
+
+        # Mock failed NGS360 API response
+        mock_get.side_effect = requests.RequestException("NGS360 connection failed")
+
+        # Test connect failure
+        platform = NGS360Platform('WES')
+        result = platform.connect(
+            api_endpoint='https://wes.example.com/ga4gh/wes/v1',
+            ngs360_endpoint='https://ngs360.example.com'
+        )
+
+        self.assertFalse(result)
 
     @patch('requests.request')
     def test_submit_task(self, mock_request):
@@ -456,75 +519,6 @@ class TestNGS360Platform(unittest.TestCase):
         Test export_file method (not supported in WES)
         '''
         self.assertIsNone(self.platform.export_file('file_id', 'bucket', 'prefix'))
-
-    @patch('requests.request')
-    def test_connect_username_password_auth(self, mock_request):
-        '''
-        Test connect method with username/password authentication
-        '''
-        # Mock WES API response
-        mock_response = MagicMock()
-        mock_response.json.return_value = {'workflow_type_versions': {'CWL': {'workflow_type_version': ['v1.0']}}}
-        mock_request.return_value = mock_response
-
-        # Mock NGS360 API response
-        with patch('requests.get') as mock_get:
-            mock_ngs360_response = MagicMock()
-            mock_ngs360_response.status_code = 200
-            mock_get.return_value = mock_ngs360_response
-
-            # Test connect with username/password
-            with patch.dict('os.environ', {'WES_USERNAME': 'testuser', 'WES_PASSWORD': 'testpass'}):
-                platform = NGS360Platform('WES')
-                result = platform.connect(
-                    api_endpoint='https://wes.example.com/ga4gh/wes/v1',
-                    ngs360_endpoint='https://ngs360.example.com'
-                )
-
-                self.assertTrue(result)
-                self.assertEqual(platform._auth_config['credentials'], ('testuser', 'testpass'))
-
-    @patch('requests.request')
-    def test_connect_wes_failure(self, mock_request):
-        '''
-        Test connect method with WES API failure
-        '''
-        # Mock failed WES API response
-        mock_request.side_effect = requests.RequestException("Connection failed")
-
-        # Test connect failure
-        platform = NGS360Platform('WES')
-        result = platform.connect(
-            api_endpoint='https://wes.example.com/ga4gh/wes/v1',
-            ngs360_endpoint='https://ngs360.example.com'
-        )
-
-        self.assertFalse(result)
-        self.assertFalse(platform.connected)
-
-    @patch('requests.get')
-    @patch('requests.request')
-    def test_connect_ngs360_failure(self, mock_request, mock_get):
-        '''
-        Test connect method with NGS360 API failure
-        '''
-        # Mock successful WES API response
-        mock_wes_response = MagicMock()
-        mock_wes_response.json.return_value = {'workflow_type_versions': {'CWL': {'workflow_type_version': ['v1.0']}}}
-        mock_request.return_value = mock_wes_response
-
-        # Mock failed NGS360 API response
-        mock_get.side_effect = requests.RequestException("NGS360 connection failed")
-
-        # Test connect failure
-        platform = NGS360Platform('WES')
-        result = platform.connect(
-            api_endpoint='https://wes.example.com/ga4gh/wes/v1',
-            ngs360_endpoint='https://ngs360.example.com'
-        )
-
-        self.assertFalse(result)
-        self.assertFalse(platform.connected)
 
     @patch('requests.get')
     def test_get_project_by_id(self, mock_get):


### PR DESCRIPTION
The use of the variable name api_endpoint is confusing since there are two API services we need to communicate with.  This PR updates the variable name to be more informative.