### PR TITLE
misc bugfixes discovered in testing

### DIFF
--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -856,8 +856,8 @@ class SevenBridgesPlatform(Platform):
     def get_project_by_name(self, project_name):
         ''' Get a project by its name '''
         projects = self.api.projects.query(name=project_name)
-        matches = [] 
         if projects:
+            matches = []
             for project in projects:
                 if project.name == project_name:
                     matches.append(project)

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -257,7 +257,7 @@ class SevenBridgesPlatform(Platform):
             file_name = path_parts[0]
             file_list = self.api.files.query(
                 project=project,
-                names=[file_path],
+                names=[file_name],
                 limit=100
             ).all()
         else:

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -857,7 +857,9 @@ class SevenBridgesPlatform(Platform):
         ''' Get a project by its name '''
         projects = self.api.projects.query(name=project_name)
         if projects:
-            return projects[0]
+            for project in projects:
+                if project.name == project_name:
+                    return project
         return None
 
     def get_project_by_id(self, project_id):

--- a/src/cwl_platform/sevenbridges_platform.py
+++ b/src/cwl_platform/sevenbridges_platform.py
@@ -856,10 +856,19 @@ class SevenBridgesPlatform(Platform):
     def get_project_by_name(self, project_name):
         ''' Get a project by its name '''
         projects = self.api.projects.query(name=project_name)
+        matches = [] 
         if projects:
             for project in projects:
                 if project.name == project_name:
-                    return project
+                    matches.append(project)
+            if len(matches)==1:
+                return matches[0]
+            elif len(matches)>1:
+                self.logger.warning("Multiple projects found with name %s. Returning None", project_name)
+                return None
+            else:
+                self.logger.warning("No project found with name %s. Returning None", project_name)
+                return None
         return None
 
     def get_project_by_id(self, project_id):

--- a/tests/test_sevenbridges_platform.py
+++ b/tests/test_sevenbridges_platform.py
@@ -975,5 +975,222 @@ class TestSevenBridgesPlaform(unittest.TestCase):
         )
         self.assertEqual(result, 'file-base')
 
+    def test_get_project_by_name_exact_match(self):
+        ''' Test that get_project_by_name returns the project with an exact name match '''
+        mock_project = MagicMock()
+        mock_project.name = 'MyProject'
+
+        self.platform.api.projects.query.return_value = [mock_project]
+
+        result = self.platform.get_project_by_name('MyProject')
+
+        self.platform.api.projects.query.assert_called_once_with(name='MyProject')
+        self.assertEqual(result, mock_project)
+
+    def test_get_project_by_name_no_results(self):
+        ''' Test that get_project_by_name returns None when query returns empty '''
+        self.platform.api.projects.query.return_value = []
+
+        result = self.platform.get_project_by_name('NonExistent')
+
+        self.assertIsNone(result)
+
+    def test_get_project_by_name_no_exact_match(self):
+        ''' Test that get_project_by_name returns None when no project name matches exactly '''
+        mock_project = MagicMock()
+        mock_project.name = 'MyProject-Extra'
+
+        self.platform.api.projects.query.return_value = [mock_project]
+
+        result = self.platform.get_project_by_name('MyProject')
+
+        self.assertIsNone(result)
+
+    def test_get_project_by_name_multiple_matches_returns_none(self):
+        ''' Test that get_project_by_name returns None when multiple exact matches exist '''
+        mock_project1 = MagicMock()
+        mock_project1.name = 'MyProject'
+        mock_project2 = MagicMock()
+        mock_project2.name = 'MyProject'
+
+        self.platform.api.projects.query.return_value = [mock_project1, mock_project2]
+
+        result = self.platform.get_project_by_name('MyProject')
+
+        self.assertIsNone(result)
+
+    def test_get_project_by_name_filters_partial_matches(self):
+        ''' Test that get_project_by_name ignores partial matches and returns exact one '''
+        mock_partial = MagicMock()
+        mock_partial.name = 'MyProject-Dev'
+        mock_exact = MagicMock()
+        mock_exact.name = 'MyProject'
+
+        self.platform.api.projects.query.return_value = [mock_partial, mock_exact]
+
+        result = self.platform.get_project_by_name('MyProject')
+
+        self.assertEqual(result, mock_exact)
+
+    def test_get_project_by_name_query_returns_none(self):
+        ''' Test that get_project_by_name handles None from api query '''
+        self.platform.api.projects.query.return_value = None
+
+        result = self.platform.get_project_by_name('MyProject')
+
+        self.assertIsNone(result)
+
+    def test_get_file_id_raises_on_url(self):
+        ''' Test that get_file_id raises ValueError when given a URL '''
+        project = MagicMock()
+        with self.assertRaises(ValueError) as context:
+            self.platform.get_file_id(project, 'http://example.com/file.txt')
+        self.assertIn('cannot be a URL', str(context.exception))
+
+    def test_get_file_id_raises_on_https_url(self):
+        ''' Test that get_file_id raises ValueError when given an HTTPS URL '''
+        project = MagicMock()
+        with self.assertRaises(ValueError) as context:
+            self.platform.get_file_id(project, 'https://example.com/file.txt')
+        self.assertIn('cannot be a URL', str(context.exception))
+
+    def test_get_file_id_s3_path_extracts_filename(self):
+        ''' Test that get_file_id strips S3 prefix and uses only the filename '''
+        project = MagicMock()
+        mock_file = MagicMock(name='sample.fastq')
+        mock_file.name = 'sample.fastq'
+        mock_file.id = 'file-123'
+
+        query_result = MagicMock()
+        query_result.all.return_value = [mock_file]
+        self.platform.api.files.query.return_value = query_result
+
+        result = self.platform.get_file_id(project, 's3://bucket/path/to/sample.fastq')
+
+        self.platform.api.files.query.assert_called_once_with(
+            project=project,
+            names=['sample.fastq'],
+            limit=100
+        )
+        self.assertEqual(result, 'file-123')
+
+    def test_get_file_id_root_level_file(self):
+        ''' Test that get_file_id finds a file at the project root '''
+        project = MagicMock()
+        mock_file = MagicMock(name='data.csv')
+        mock_file.name = 'data.csv'
+        mock_file.id = 'file-456'
+
+        query_result = MagicMock()
+        query_result.all.return_value = [mock_file]
+        self.platform.api.files.query.return_value = query_result
+
+        result = self.platform.get_file_id(project, 'data.csv')
+
+        self.platform.api.files.query.assert_called_once_with(
+            project=project,
+            names=['data.csv'],
+            limit=100
+        )
+        self.assertEqual(result, 'file-456')
+
+    @mock.patch.object(SevenBridgesPlatform, '_list_files_in_folder')
+    def test_get_file_id_file_in_folder(self, mock_list_files):
+        ''' Test that get_file_id finds a file inside a folder '''
+        project = MagicMock()
+        mock_file = MagicMock(name='result.bam')
+        mock_file.name = 'result.bam'
+        mock_file.id = 'file-789'
+
+        mock_list_files.return_value = [mock_file]
+
+        result = self.platform.get_file_id(project, 'outputs/result.bam')
+
+        mock_list_files.assert_called_once_with(
+            project=project,
+            folder='outputs'
+        )
+        self.assertEqual(result, 'file-789')
+
+    @mock.patch.object(SevenBridgesPlatform, '_list_files_in_folder')
+    def test_get_file_id_file_in_nested_folder(self, mock_list_files):
+        ''' Test that get_file_id handles a nested folder path '''
+        project = MagicMock()
+        mock_file = MagicMock(name='variants.vcf')
+        mock_file.name = 'variants.vcf'
+        mock_file.id = 'file-nested'
+
+        mock_list_files.return_value = [mock_file]
+
+        result = self.platform.get_file_id(project, 'results/pipeline/variants.vcf')
+
+        mock_list_files.assert_called_once_with(
+            project=project,
+            folder='results/pipeline'
+        )
+        self.assertEqual(result, 'file-nested')
+
+    def test_get_file_id_file_not_found_raises(self):
+        ''' Test that get_file_id raises ValueError when file is not found '''
+        project = MagicMock()
+
+        query_result = MagicMock()
+        query_result.all.return_value = []
+        self.platform.api.files.query.return_value = query_result
+
+        with self.assertRaises(ValueError) as context:
+            self.platform.get_file_id(project, 'nonexistent.txt')
+        self.assertIn('File not found', str(context.exception))
+
+    @mock.patch.object(SevenBridgesPlatform, '_list_files_in_folder')
+    def test_get_file_id_file_not_found_in_folder_raises(self, mock_list_files):
+        ''' Test that get_file_id raises ValueError when file is not in folder '''
+        project = MagicMock()
+        mock_other_file = MagicMock(name='other.txt')
+        mock_other_file.name = 'other.txt'
+
+        mock_list_files.return_value = [mock_other_file]
+
+        with self.assertRaises(ValueError) as context:
+            self.platform.get_file_id(project, 'folder/missing.txt')
+        self.assertIn('File not found', str(context.exception))
+
+    def test_get_file_id_returns_first_match(self):
+        ''' Test that get_file_id returns the first file when multiple matches exist '''
+        project = MagicMock()
+        mock_file1 = MagicMock(name='data.csv')
+        mock_file1.name = 'data.csv'
+        mock_file1.id = 'file-first'
+        mock_file2 = MagicMock(name='data.csv')
+        mock_file2.name = 'data.csv'
+        mock_file2.id = 'file-second'
+
+        query_result = MagicMock()
+        query_result.all.return_value = [mock_file1, mock_file2]
+        self.platform.api.files.query.return_value = query_result
+
+        result = self.platform.get_file_id(project, 'data.csv')
+
+        self.assertEqual(result, 'file-first')
+
+    def test_get_file_id_filters_by_name(self):
+        ''' Test that get_file_id filters results to match the exact filename '''
+        project = MagicMock()
+        mock_file_wrong = MagicMock(name='data_old.csv')
+        mock_file_wrong.name = 'data_old.csv'
+        mock_file_wrong.id = 'file-wrong'
+        mock_file_right = MagicMock(name='data.csv')
+        mock_file_right.name = 'data.csv'
+        mock_file_right.id = 'file-right'
+
+        query_result = MagicMock()
+        query_result.all.return_value = [mock_file_wrong, mock_file_right]
+        self.platform.api.files.query.return_value = query_result
+
+        result = self.platform.get_file_id(project, 'data.csv')
+
+        self.assertEqual(result, 'file-right')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes various bugs discovered while testing the RNA/WES/WGS that do not have any relation to the changes made to support the crispr-dav pipeline. The changes include:

### SBG get_project_by_name()
* Context: This method works by calling `self.api.projects.query(name=project_name)`, which returns a list of project objects whose names contain `project_name` as a substring. Then, get_project_by_name() returns the first project in that list. 
* Problem: This was causing an issue in the RNA seq pipeline because the reference project name is 'RNA-Seq Reference', but there is now another project named 'RNA-Seq Reference Generate'. When trying to copy reference files from the reference project, get_project_by_name() returned the 'RNA-Seq Reference Generate' project which does not contain the needed files.
* Fix: Loop through the project list returned by `self.api.projects.query(name=project_name)` and check that names exactly match the query. If multiple or no names match, return None. 

### SBG get_file_id()
* Problem: This method derives the file_name from the file_path parameter, but then never uses file_name in the api call. This causes files in the project root to not be found when there is a leading slash in the file_path parameter. 
* Fix: Actually use the file_name variable.