### PR TITLE
Implement Claude suggestions to release process

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,26 +1,108 @@
-# GitHub Release Process
+# Release Process
 
-This (vaguely) follows the guidance of [Python Package Template](https://github.com/allenai/python-package-template)
+This follows the guidance of [Python Package Template](https://github.com/allenai/python-package-template)
 
-## Steps
+## Prerequisites
 
-1. Update the version in `pyproject.toml`.
+Before starting a release, ensure:
 
-2. Run the release script:
+- All tests pass: `pytest`
+- Working directory is clean: `git status`
+- On the main branch with latest changes: `git pull origin main`
+- CHANGELOG.md exists (will be auto-created if missing)
 
-    ```bash
-    ./scripts/release.sh
-    ```
+## Quick Release
 
-    This will commit the changes to the CHANGELOG and `pyproject.toml` files and then create a new tag in git
-    which will trigger a workflow on GitHub Actions that handles the rest.
+1. **Bump version** in `pyproject.toml`
+   
+   Update the version number (e.g., `0.5.1` → `0.5.2`):
+   ```toml
+   [project]
+   name = "cwl_platform"
+   version = "0.5.2"  # Update this line
+   ```
 
-## Fixing a failed release
+2. **Run the release script:**
+   ```bash
+   ./scripts/release.sh
+   ```
+   
+   The script will:
+   - Validate your environment (branch, uncommitted changes, etc.)
+   - Optionally run tests
+   - Generate CHANGELOG entries from git commits
+   - Pause for you to review/edit CHANGELOG.md
+   - Commit version and CHANGELOG changes
+   - Create and push a git tag (e.g., `v0.5.2`)
+   - Trigger GitHub Actions to build and publish
 
-If for some reason the GitHub Actions release workflow failed with an error that needs to be fixed, you'll have to delete both the tag and corresponding release from GitHub. After you've pushed a fix, delete the tag from your local clone with
+3. **Finalize on GitHub:**
+   - Navigate to https://github.com/NGS360/PAML/releases
+   - Review the draft release created by GitHub Actions
+   - Verify release notes and artifacts
+   - Click **"Publish release"**
 
-```bash
-git tag -l | xargs git tag -d && git fetch -t
-```
+## Troubleshooting
 
-Then repeat the steps above.
+### Failed Release Recovery
+
+If the GitHub Actions workflow fails after the tag is pushed:
+
+1. **Delete the failed tag:**
+   ```bash
+   TAG="v0.5.2"  # Replace with your version
+   git tag -d $TAG              # Delete locally
+   git push --delete origin $TAG  # Delete from GitHub
+   ```
+
+2. **Delete the draft release on GitHub** (if one was created):
+   - Go to https://github.com/NGS360/PAML/releases
+   - Find the draft release and delete it
+
+3. **Fix the issue**, then repeat the release steps above
+
+### Editing CHANGELOG Before Release
+
+The release script pauses after generating CHANGELOG entries. At this point:
+
+1. Review the auto-generated changes in `CHANGELOG.md`
+2. Edit to add context, group related changes, or improve descriptions
+3. Press Enter to continue with the release
+
+### Rollback a Published Release
+
+If you need to retract a published release:
+
+1. **Mark as pre-release** on GitHub (or delete the release entirely)
+2. **Note**: PyPI doesn't allow re-uploading the same version number
+3. **Create a new patch version** with the fix (e.g., `0.5.3`)
+
+## Release Script Validations
+
+The `release.sh` script performs these checks:
+
+- ✓ Extracts version from `pyproject.toml`
+- ✓ Verifies you're on the `main` branch
+- ✓ Checks for uncommitted changes
+- ✓ Confirms tag doesn't already exist (local and remote)
+- ✓ Offers to run tests before releasing
+- ✓ Ensures local branch is up-to-date with remote
+- ✓ Creates `CHANGELOG.md` if missing
+
+## Version Numbering
+
+Follow [Semantic Versioning](https://semver.org/):
+
+- **Patch** (0.5.1 → 0.5.2): Bug fixes, minor changes
+- **Minor** (0.5.2 → 0.6.0): New features, backwards-compatible
+- **Major** (0.6.0 → 1.0.0): Breaking changes
+
+## What Happens on GitHub Actions
+
+When you push a tag, the `.github/workflows/release.yml` workflow:
+
+1. Checks out the code
+2. Builds the Python package (`python3 -m build`)
+3. Generates release notes from `CHANGELOG.md`
+4. Creates a **draft release** on GitHub with built artifacts
+5. Waits for you to manually publish the release

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,18 +1,153 @@
 #!/bin/bash -e
 
+# Configuration
 REPO=https://github.com/NGS360/PAML.git
+MAIN_BRANCH="main"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Helper functions
+error() {
+    echo -e "${RED}ERROR: $1${NC}" >&2
+    exit 1
+}
+
+warning() {
+    echo -e "${YELLOW}WARNING: $1${NC}"
+}
+
+success() {
+    echo -e "${GREEN}$1${NC}"
+}
+
+# Extract version from pyproject.toml
 TAG=$(grep version pyproject.toml | cut -d '=' -f2 | sed 's/"//g' | tr -d '[:space:]')
+[[ -z "$TAG" ]] && error "Could not extract version from pyproject.toml"
+
+echo "=== Release Validation for v$TAG ==="
+echo ""
+
+# 1. Check if on main branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" != "$MAIN_BRANCH" ]]; then
+    warning "Not on $MAIN_BRANCH branch (currently on: $CURRENT_BRANCH)"
+    read -p "Continue anyway? [y/N] " prompt
+    [[ ! $prompt =~ ^[Yy]$ ]] && error "Release cancelled. Switch to $MAIN_BRANCH branch first."
+fi
+
+# 2. Check for uncommitted changes
+if [[ -n $(git status --porcelain) ]]; then
+    warning "Working directory has uncommitted changes:"
+    git status --short
+    read -p "Continue anyway? [y/N] " prompt
+    [[ ! $prompt =~ ^[Yy]$ ]] && error "Release cancelled. Commit or stash changes first."
+fi
+
+# 3. Check if tag already exists
+if git rev-parse "v$TAG" >/dev/null 2>&1; then
+    error "Tag v$TAG already exists. Update version in pyproject.toml first."
+fi
+
+# 4. Check if remote tag exists
+if git ls-remote --tags origin | grep -q "refs/tags/v$TAG"; then
+    error "Tag v$TAG already exists on remote. Update version in pyproject.toml first."
+fi
+
+# 5. Check if tests exist and offer to run them
+if [[ -f "pytest.ini" ]] || [[ -f "tests/test_*.py" ]] || [[ -f "test_*.py" ]]; then
+    read -p "Run tests before release? [Y/n] " prompt
+    if [[ $prompt == "n" || $prompt == "N" || $prompt == "no" || $prompt == "No" ]]; then
+        warning "Skipping tests"
+    else
+        echo "Running tests..."
+        if ! pytest; then
+            error "Tests failed. Fix tests before releasing."
+        fi
+        success "Tests passed ✓"
+    fi
+fi
+
+# 6. Fetch latest from remote
+echo "Fetching latest changes from remote..."
+git fetch origin
+
+# 7. Check if local is behind remote
+LOCAL=$(git rev-parse @)
+REMOTE=$(git rev-parse @{u} 2>/dev/null || echo "")
+if [[ -n "$REMOTE" ]] && [[ "$LOCAL" != "$REMOTE" ]]; then
+    BASE=$(git merge-base @ @{u})
+    if [[ "$LOCAL" = "$BASE" ]]; then
+        error "Local branch is behind remote. Run 'git pull' first."
+    elif [[ "$REMOTE" != "$BASE" ]]; then
+        warning "Local and remote have diverged"
+    fi
+fi
+
+# 8. Check CHANGELOG.md exists
+if [[ ! -f "CHANGELOG.md" ]]; then
+    warning "CHANGELOG.md not found"
+    read -p "Create a basic CHANGELOG.md? [Y/n] " prompt
+    if [[ ! $prompt =~ ^[Nn]$ ]]; then
+        cat > CHANGELOG.md << EOF
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+EOF
+        git add CHANGELOG.md
+        success "Created CHANGELOG.md"
+    fi
+fi
+
+echo ""
+echo "=== Release Summary ==="
+echo "Version: v$TAG"
+echo "Branch: $CURRENT_BRANCH"
+echo "Repository: $REPO"
+echo ""
 
 read -p "Creating new release for v$TAG. Do you want to continue? [Y/n] " prompt
 
-if [[ $prompt == "y" || $prompt == "Y" || $prompt == "yes" || $prompt == "Yes" ]]; then
+if [[ $prompt == "y" || $prompt == "Y" || $prompt == "yes" || $prompt == "Yes" || $prompt == "" ]]; then
+    echo ""
+    echo "Preparing CHANGELOG..."
     python3 scripts/prepare_changelog.py $REPO $TAG
-    # It appears here is where you need to manually add information to the CHANGELOG.md
+
+    echo ""
+    warning "CHANGELOG has been updated. Please review and edit if needed."
+    echo "Press Enter to continue after reviewing CHANGELOG.md, or Ctrl+C to cancel..."
+    read
+
+    echo "Committing changes..."
     git add -A
-    git commit -m "Bump version to $TAG for release" || true && git push
-    echo "Creating new git tag $TAG"
+    if git commit -m "Bump version to $TAG for release"; then
+        success "Changes committed ✓"
+    else
+        warning "No changes to commit (this is OK if version was already committed)"
+    fi
+
+    echo "Pushing to remote..."
+    git push
+    success "Changes pushed ✓"
+
+    echo "Creating git tag v$TAG..."
     git tag "v$TAG" -m "v$TAG"
+    success "Tag created ✓"
+
+    echo "Pushing tag to remote..."
     git push --tags
+    success "Tag pushed ✓"
+
+    echo ""
+    success "=== Release v$TAG initiated successfully! ==="
+    echo "GitHub Actions will now build and create a draft release."
+    echo "Visit: $REPO/releases to review and publish the release."
 else
     echo "Cancelled"
     exit 1


### PR DESCRIPTION
  Updated scripts/release.sh

  Added comprehensive validations:
  - ✅ Checks if on main branch (warns if not)
  - ✅ Detects uncommitted changes
  - ✅ Verifies tag doesn't already exist (local & remote)
  - ✅ Offers to run tests before release
  - ✅ Checks if local is behind remote
  - ✅ Creates CHANGELOG.md if missing
  - ✅ Color-coded output (red errors, yellow warnings, green success)
  - ✅ Pauses after CHANGELOG generation for manual review
  - ✅ Better error messages with actionable guidance

  Updated RELEASE_PROCESS.md

  Streamlined with:
  - ✅ Clear prerequisites section
  - ✅ Step-by-step quick release guide
  - ✅ Specific troubleshooting instructions (no more deleting ALL tags)
  - ✅ Explains the CHANGELOG editing pause point
  - ✅ Documents what validations the script performs
  - ✅ Adds semantic versioning guidance
  - ✅ Clarifies what happens in GitHub Actions

  The new process is much safer and more user-friendly, with validations preventing common mistakes like releasing with uncommitted changes,
  duplicate tags, or outdated local branches.
